### PR TITLE
Stop TruncatedText from overflowing when width is below the ellipsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.2.1] - Unreleased
-- TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper.
+- TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper. Thanks @devYRPauli.
 
 ## [0.2.0] - 2026-06-10
 - Autocomplete suggestions can now be constructed by external TauTUI clients. Thanks @dcartman.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.2.1] - Unreleased
+- TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper.
 
 ## [0.2.0] - 2026-06-10
 - Autocomplete suggestions can now be constructed by external TauTUI clients. Thanks @dcartman.

--- a/Sources/TauTUI/Components/TruncatedText.swift
+++ b/Sources/TauTUI/Components/TruncatedText.swift
@@ -50,6 +50,10 @@ public final class TruncatedText: Component {
         guard visible > maxVisibleWidth else { return firstLine }
 
         let target = max(0, maxVisibleWidth - 3) // space for "..."
+        if target <= 0 {
+            // Not enough room for the full ellipsis; fill with as many dots as fit.
+            return "\u{001B}[0m" + String(repeating: ".", count: maxVisibleWidth)
+        }
         var currentWidth = 0
         var truncateAt = firstLine.startIndex
         var index = firstLine.startIndex

--- a/Tests/TauTUITests/TruncatedTextTests.swift
+++ b/Tests/TauTUITests/TruncatedTextTests.swift
@@ -40,6 +40,14 @@ struct TruncatedTextTests {
     }
 
     @Test
+    func `does not overflow when width is below the ellipsis width`() {
+        let text = TruncatedText(text: "Hello world", paddingX: 0, paddingY: 0)
+        let lines = text.render(width: 2)
+        #expect(lines.count == 1)
+        #expect(VisibleWidth.measure(lines[0]) == 2)
+    }
+
+    @Test
     func `handles empty text`() {
         let text = TruncatedText(text: "", paddingX: 1, paddingY: 0)
         let lines = text.render(width: 30)


### PR DESCRIPTION
### What

`TruncatedText` is documented as single-line text that "truncates with an ellipsis and pads to the viewport width." The private `truncatedLine` computes room for the ellipsis but then appends the full three-dot `"..."` unconditionally:

```swift
let target = max(0, maxVisibleWidth - 3) // space for "..."
...
return prefix + "\u{001B}[0m..."
```

When `maxVisibleWidth` is 1 or 2, `target` is 0, the loop adds no characters, and the method returns a string whose visible width is 3 - wider than the width it was asked to fit. That breaks the pad-to-width invariant the component guarantees (the right pad clamps to 0 and the line overflows).

The public `truncate(_:toWidth:)` helper already handles exactly this case:

```swift
let target = maxWidth - ellipsisWidth
if target <= 0 {
    return String(ellipsis.prefix(maxWidth))
}
```

### Fix

Mirror that guard in `truncatedLine`: when there is no room for the ellipsis, fill with as many dots as fit.

```swift
let target = max(0, maxVisibleWidth - 3) // space for "..."
if target <= 0 {
    return "\u{001B}[0m" + String(repeating: ".", count: maxVisibleWidth)
}
```

At `maxVisibleWidth >= 3` the output is unchanged (byte-identical at width 3), so only the previously-overflowing widths 1 and 2 are affected.

### Test

Added a case to `TruncatedTextTests`: rendering at `width: 2` (with `paddingX: 0`) must produce a line of visible width 2. It fails before the change (measures 3) and passes after. Full suite green (149 tests).



Update: added real behavior proof in a comment below - runtime main-vs-fix result for `render(width: 2)` plus `swift test` output.
