### PR TITLE
chore(deps): refresh Swift toolchain and system pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Swift 6.2
+      - name: Install Swift 6.3.3
         uses: SwiftyLab/setup-swift@v1.14.0
         with:
-          swift-version: "6.2"
+          swift-version: "6.3.3"
 
       - name: Install linters (SwiftLint & SwiftFormat)
         run: |
@@ -31,16 +31,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
+        swift-version: ["6.2", "6.3.3"]
     runs-on: ${{ matrix.os }}
     needs: lint
 
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install Swift 6.2
+      - name: Install Swift ${{ matrix.swift-version }}
         uses: SwiftyLab/setup-swift@v1.14.0
         with:
-          swift-version: "6.2"
+          swift-version: ${{ matrix.swift-version }}
 
       - name: Show Swift version
         run: swift --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
 
       - name: Install linters (SwiftLint & SwiftFormat)
         run: |
+          brew update
           brew install swiftlint swiftformat
 
       - name: SwiftLint

--- a/.swiftformat
+++ b/.swiftformat
@@ -29,6 +29,7 @@
 --wrapparameters before-first
 --wrapcollections before-first
 --closingparen same-line
+--disable wrapIfStatementBodies
 
 # Organization
 --organizetypes class,struct,enum,extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.1] - Unreleased
 - TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper. Thanks @devYRPauli.
+- Refresh the swift-system dependency pin from 1.7.2 to 1.7.4.
 
 ## [0.2.0] - 2026-06-10
 - Autocomplete suggestions can now be constructed by external TauTUI clients. Thanks @dcartman.

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7502b711c92a17741fa625d722b0ccbd595d8ed1",
-        "version" : "1.7.2"
+        "revision" : "b5544ba79a70a0cb3563e75bf26dc198d6b40ed3",
+        "version" : "1.7.4"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- refresh the locked `swift-system` dependency from 1.7.2 to 1.7.4
- retain Swift 6.2 as the minimum while adding Swift 6.3.3 to the Linux/macOS CI matrix
- preserve the repository's existing formatting under the current SwiftFormat rule set

## Validation

- Swift 6.2.4 x86_64 Linux container: debug build, 149 tests, release build
- local debug and release builds
- SwiftLint and SwiftFormat
- actionlint and `git diff --check`
- OSV scan: zero known vulnerabilities
- dependency freshness and public-model identifier gate
- structured AutoReview; its sole setup-action finding was rejected after verification against the tagged action source and current contract metadata
