### PR TITLE
fix: harden terminal rendering invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.2.2] - Unreleased
+- Input scrolling now uses terminal columns so CJK, fullwidth, and emoji text cannot overflow the viewport.
+- ProcessTerminal shutdown is now idempotent and no longer writes terminal-mode resets when the terminal was never started.
+- TUI sessions no longer render after shutdown, reuse stale render state after restart, or leave old rows visible when content becomes empty.
 
 ## [0.2.1] - 2026-07-15
 - TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper. Thanks @devYRPauli.

--- a/Sources/TauTUI/Components/Input.swift
+++ b/Sources/TauTUI/Components/Input.swift
@@ -212,19 +212,51 @@ public final class Input: Component {
     }
 
     private func windowedValue(available: Int) -> (String, Int) {
-        if self.value.count <= available {
+        let totalWidth = VisibleWidth.measure(self.value)
+        let cursorAtEnd = self.cursor == self.value.count
+        let cursorWidth = cursorAtEnd ? 1 : 0
+        if totalWidth + cursorWidth <= available {
             return (self.value, self.cursor)
         }
-        let cursorAtEnd = self.cursor == self.value.count
+
         let scrollWidth = cursorAtEnd ? available - 1 : available
+        guard scrollWidth > 0 else { return ("", 0) }
+
+        let beforeCursor = String(self.value.prefix(self.cursor))
+        let cursorColumn = VisibleWidth.measure(beforeCursor)
         let half = scrollWidth / 2
-        var startIndex = self.cursor - half
-        startIndex = max(0, min(startIndex, self.value.count - scrollWidth))
-        let start = self.value.index(self.value.startIndex, offsetBy: startIndex)
-        let end = self.value.index(start, offsetBy: min(scrollWidth, self.value.count - startIndex))
-        let visible = String(value[start..<end])
-        let cursorDisplay = cursorAtEnd ? visible.count : self.cursor - startIndex
+        let startColumn = if cursorColumn < half {
+            0
+        } else if cursorColumn > totalWidth - half {
+            max(0, totalWidth - scrollWidth)
+        } else {
+            max(0, cursorColumn - half)
+        }
+
+        let visible = self.sliceByColumns(self.value, start: startColumn, width: scrollWidth)
+        let visibleBeforeCursor = self.sliceByColumns(
+            self.value,
+            start: startColumn,
+            width: max(0, cursorColumn - startColumn))
+        let cursorDisplay = visibleBeforeCursor.count
         return (visible, cursorDisplay)
+    }
+
+    private func sliceByColumns(_ text: String, start: Int, width: Int) -> String {
+        guard width > 0 else { return "" }
+
+        let end = start + width
+        var column = 0
+        var result = ""
+        for grapheme in text {
+            let graphemeWidth = VisibleWidth.measure(String(grapheme))
+            if column >= start, column < end, column + graphemeWidth <= end {
+                result.append(grapheme)
+            }
+            column += graphemeWidth
+            if column >= end { break }
+        }
+        return result
     }
 
     @MainActor public func apply(theme: ThemePalette) {

--- a/Sources/TauTUI/Core/TUI.swift
+++ b/Sources/TauTUI/Core/TUI.swift
@@ -18,6 +18,8 @@ public final class TUI: Container {
     private var previousWidth: Int = 0
     private var cursorRow: Int = 0
     private var renderRequested = false
+    private var isRunning = false
+    private var sessionGeneration: UInt = 0
 
     /// Called when Ctrl+C is received. If unset, Ctrl+C will stop the terminal and call `exit(0)`.
     public var onControlC: (@MainActor @Sendable () -> Void)?
@@ -43,12 +45,21 @@ public final class TUI: Container {
         }, onResize: { [weak self] in
             self?.requestRender()
         })
+        self.isRunning = true
+        self.sessionGeneration &+= 1
         self.terminal.hideCursor()
         self.queryCellSizeIfNeeded()
         self.requestRender()
     }
 
     public func stop() {
+        guard self.isRunning else { return }
+        self.isRunning = false
+        self.sessionGeneration &+= 1
+        self.renderRequested = false
+        self.previousLines = []
+        self.previousWidth = 0
+        self.cursorRow = 0
         self.terminal.showCursor()
         self.terminal.stop()
     }
@@ -61,10 +72,12 @@ public final class TUI: Container {
     }
 
     public func requestRender() {
+        guard self.isRunning else { return }
         guard !self.renderRequested else { return }
         self.renderRequested = true
+        let generation = self.sessionGeneration
         self.scheduleRender { @MainActor [weak self] in
-            guard let self else { return }
+            guard let self, self.isRunning, self.sessionGeneration == generation else { return }
             self.renderRequested = false
             self.performRender()
         }
@@ -112,6 +125,9 @@ public final class TUI: Container {
         let newLines = render(width: width)
 
         guard !newLines.isEmpty else {
+            if !self.previousLines.isEmpty {
+                self.writePartialRender(lines: [""], from: 0)
+            }
             self.previousLines = []
             self.previousWidth = width
             self.cursorRow = 0

--- a/Sources/TauTUI/Terminal/Terminal.swift
+++ b/Sources/TauTUI/Terminal/Terminal.swift
@@ -74,8 +74,8 @@ public enum TerminalError: Error {
 // MARK: - ProcessTerminal
 
 public final class ProcessTerminal: Terminal {
-    private let inputFD = FileDescriptor.standardInput
-    private let outputFD = FileDescriptor.standardOutput
+    private let inputFD: FileDescriptor
+    private let outputFD: FileDescriptor
 
     private var stdinSource: DispatchSourceRead?
     private var resizeSource: DispatchSourceSignal?
@@ -84,6 +84,7 @@ public final class ProcessTerminal: Terminal {
 
     private var originalTermios = termios()
     private var rawModeEnabled = false
+    private var terminalModesEnabled = false
 
     private var pendingInput = ""
     private var isInBracketedPaste = false
@@ -106,7 +107,16 @@ public final class ProcessTerminal: Terminal {
     private static let optionEnterCSI = "\u{001B}[13;3~"
     private static let optionEnterMeta = "\u{001B}\r"
 
-    public init() {}
+    public convenience init() {
+        self.init(
+            inputFileDescriptor: FileDescriptor.standardInput.rawValue,
+            outputFileDescriptor: FileDescriptor.standardOutput.rawValue)
+    }
+
+    init(inputFileDescriptor: Int32, outputFileDescriptor: Int32) {
+        self.inputFD = FileDescriptor(rawValue: inputFileDescriptor)
+        self.outputFD = FileDescriptor(rawValue: outputFileDescriptor)
+    }
 
     /// Testing helper: parse a raw input string into `TerminalInput` events
     /// without starting Dispatch sources. Only used in unit tests.
@@ -133,6 +143,7 @@ public final class ProcessTerminal: Terminal {
         try self.enableRawMode()
         self.write("\u{001B}[?2004h") // bracketed paste on
         self.write(Self.kittyKeyboardProtocolEnable) // kitty keyboard protocol on
+        self.terminalModesEnabled = true
 
         let source = DispatchSource.makeReadSource(fileDescriptor: self.inputFD.rawValue, queue: .main)
         source.setEventHandler { [weak self] in
@@ -168,8 +179,11 @@ public final class ProcessTerminal: Terminal {
         self.resizeSource?.cancel()
         self.resizeSource = nil
 
-        self.write("\u{001B}[?2004l") // bracketed paste off
-        self.write(Self.kittyKeyboardProtocolDisable) // kitty keyboard protocol off
+        if self.terminalModesEnabled {
+            self.write("\u{001B}[?2004l") // bracketed paste off
+            self.write(Self.kittyKeyboardProtocolDisable) // kitty keyboard protocol off
+            self.terminalModesEnabled = false
+        }
         self.disableRawMode()
 
         self.inputHandler = nil

--- a/Tests/TauTUITests/InputTests.swift
+++ b/Tests/TauTUITests/InputTests.swift
@@ -76,4 +76,45 @@ struct InputTests {
         input.handle(input: .key(.character("Y")))
         #expect(input.value == "hello XworldY")
     }
+
+    @Test
+    func `render does not overflow with wide text at any cursor position`() {
+        let width = 20
+        let values = [
+            "가나다라마바사아자차카타파하",
+            "これは日本語のテキストです",
+            "ＡＢＣＤＥＦＧＨＩＪＫＬ",
+        ]
+
+        for value in values {
+            let atStart = Input(value: value)
+            atStart.handle(input: .key(.home))
+
+            let inMiddle = Input(value: value)
+            inMiddle.handle(input: .key(.home))
+            for _ in 0..<5 {
+                inMiddle.handle(input: .key(.arrowRight))
+            }
+
+            let atEnd = Input(value: value)
+
+            for input in [atStart, inMiddle, atEnd] {
+                let line = input.render(width: width)[0]
+                #expect(VisibleWidth.measure(line) <= width)
+            }
+        }
+    }
+
+    @Test
+    func `render keeps the cursor on a whole grapheme`() {
+        let family = "👨‍👩‍👧‍👦"
+        let input = Input(value: "a\(family)b")
+        input.handle(input: .key(.home))
+        input.handle(input: .key(.arrowRight))
+
+        let line = input.render(width: 8)[0]
+
+        #expect(line.contains("\u{001B}[7m\(family)\u{001B}[27m"))
+        #expect(VisibleWidth.measure(line) <= 8)
+    }
 }

--- a/Tests/TauTUITests/TUITests.swift
+++ b/Tests/TauTUITests/TUITests.swift
@@ -88,6 +88,55 @@ struct TUIRenderingTests {
     }
 
     @MainActor @Test
+    func `rendering no lines clears all previous lines`() throws {
+        let terminal = VirtualTerminal(columns: 20, rows: 5)
+        let tui = TUI(terminal: terminal, renderScheduler: { $0() })
+        let component = DummyComponent(lines: ["one", "two", "three"])
+        tui.addChild(component)
+        try tui.start()
+
+        component.lines = []
+        tui.requestRender()
+
+        let last = terminal.outputLog.last ?? ""
+        #expect(last.components(separatedBy: "\u{001B}[2K").count - 1 == 3)
+    }
+
+    @MainActor @Test
+    func `queued render does not write after stop`() throws {
+        let terminal = VirtualTerminal(columns: 20, rows: 5)
+        var scheduledRenders: [@MainActor @Sendable () -> Void] = []
+        let tui = TUI(terminal: terminal, renderScheduler: { scheduledRenders.append($0) })
+        tui.addChild(DummyComponent(lines: ["Hello"]))
+        try tui.start()
+        #expect(scheduledRenders.count == 1)
+
+        tui.stop()
+        let outputAfterStop = terminal.outputLog
+        scheduledRenders.removeFirst()()
+
+        #expect(terminal.outputLog == outputAfterStop)
+    }
+
+    @MainActor @Test
+    func `restart ignores a queued render from the previous session`() throws {
+        let terminal = VirtualTerminal(columns: 20, rows: 5)
+        var scheduledRenders: [@MainActor @Sendable () -> Void] = []
+        let tui = TUI(terminal: terminal, renderScheduler: { scheduledRenders.append($0) })
+        tui.addChild(DummyComponent(lines: ["Hello"]))
+        try tui.start()
+        tui.stop()
+        try tui.start()
+        #expect(scheduledRenders.count == 2)
+
+        scheduledRenders.removeFirst()()
+        #expect(!terminal.outputLog.contains(where: { $0.contains("Hello") }))
+
+        scheduledRenders.removeFirst()()
+        #expect(terminal.outputLog.contains(where: { $0.contains("Hello") }))
+    }
+
+    @MainActor @Test
     func `control C invokes handler and skips focused component`() throws {
         let terminal = VirtualTerminal(columns: 20, rows: 5)
         let tui = TUI(terminal: terminal, renderScheduler: { $0() })
@@ -187,5 +236,20 @@ struct TUIRenderingTests {
         let parser = ProcessTerminal()
         let events = parser.parseForTests("\n")
         #expect(events.contains(where: { if case .key(.enter, _) = $0 { return true }; return false }))
+    }
+
+    @Test
+    func `stopping an unstarted process terminal does not write terminal control sequences`() throws {
+        let outputPipe = Pipe()
+        do {
+            let terminal = ProcessTerminal(
+                inputFileDescriptor: FileHandle.standardInput.fileDescriptor,
+                outputFileDescriptor: outputPipe.fileHandleForWriting.fileDescriptor)
+            terminal.stop()
+        }
+        try outputPipe.fileHandleForWriting.close()
+
+        let output = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        #expect(output.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary

- window single-line input by terminal display columns so wide Unicode cannot overflow the viewport
- make process-terminal shutdown idempotent and suppress mode resets when no modes were enabled
- invalidate queued renders across stop/restart and clear stale rows when content becomes empty

## Testing

- `swiftformat --lint .`
- `swiftlint lint --strict`
- `swift test --parallel` (155 tests)
- source-blind repeated test-run validation with zero unexpected bracketed-paste or Kitty reset escapes
- autoreview: clean

## Documentation

- updated the 0.2.2 Unreleased changelog
