### PR TITLE
fix: harden terminal input and text state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.2.2] - Unreleased
+- Editor pastes are now inserted atomically without per-character autocomplete work, stale hidden paste payloads are discarded when markers or editor text change, and payloads containing `$` or backslashes expand literally on submit.
+- Editor and Input now share one Unicode-preserving paste sanitizer that strips terminal control characters and normalizes tabs and line endings.
+- Open autocomplete suggestions now refresh after cursor movement and text deletion instead of applying results computed for a stale cursor position.
+- ProcessTerminal now preserves split UTF-8 scalars, CSI/Kitty key sequences, and bracketed-paste delimiters across arbitrary descriptor read boundaries.
+- Background styles now always finish with a reset instead of leaking their color into later terminal output.
+- ANSI-aware wrapping now treats CRLF and CR as line endings, preserving line boundaries from cross-platform terminal output.
+- ChatDemo no longer retains its view model through the editor submit callback and builds without Swift 6.4 capture warnings.
 - Input scrolling now uses terminal columns so CJK, fullwidth, and emoji text cannot overflow the viewport.
 - ProcessTerminal shutdown is now idempotent and no longer writes terminal-mode resets when the terminal was never started.
 - TUI sessions no longer render after shutdown, reuse stale render state after restart, or leave old rows visible when content becomes empty.

--- a/Examples/ChatDemo/main.swift
+++ b/Examples/ChatDemo/main.swift
@@ -43,7 +43,8 @@ struct ChatDemo {
         vm.tui.addChild(vm.editor)
         vm.tui.setFocus(vm.editor)
 
-        vm.editor.onSubmit = { value in
+        vm.editor.onSubmit = { [weak vm] value in
+            guard let vm else { return }
             let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return }
 

--- a/Sources/TauTUI/Components/Editor.swift
+++ b/Sources/TauTUI/Components/Editor.swift
@@ -95,7 +95,10 @@ public final class Editor: Component {
     }
 
     public func setText(_ text: String) {
+        self.cancelAutocomplete()
         self.historyIndex = -1 // exit history browsing mode
+        self.pastes.removeAll(keepingCapacity: false)
+        self.pasteCounter = 0
         self.buffer.setText(text)
         self.onChange?(self.getText())
     }
@@ -118,6 +121,7 @@ public final class Editor: Component {
         guard newIndex >= -1, newIndex < self.history.count else { return }
 
         self.historyIndex = newIndex
+        self.cancelAutocomplete()
         let text = self.historyIndex == -1 ? "" : (self.history[self.historyIndex])
         self.buffer.setText(text)
         self.onChange?(self.getText())
@@ -244,28 +248,34 @@ public final class Editor: Component {
             } else {
                 self.moveCursorVisual(deltaLine: -1)
             }
+            self.updateAutocomplete()
         case .arrowDown:
             if self.historyIndex > -1, self.isOnLastVisualLine() {
                 self.navigateHistory(1)
             } else {
                 self.moveCursorVisual(deltaLine: 1)
             }
+            self.updateAutocomplete()
         case .arrowLeft:
             if modifiers.contains(.option) || modifiers.contains(.control) {
                 self.moveByWord(-1)
             } else {
                 self.moveCursorHorizontal(deltaCol: -1)
             }
+            self.updateAutocomplete()
         case .arrowRight:
             if modifiers.contains(.option) || modifiers.contains(.control) {
                 self.moveByWord(1)
             } else {
                 self.moveCursorHorizontal(deltaCol: 1)
             }
+            self.updateAutocomplete()
         case .home:
             self.buffer = self.withMutatingBuffer { buf in buf.moveToLineStart() }
+            self.updateAutocomplete()
         case .end:
             self.buffer = self.withMutatingBuffer { buf in buf.moveToLineEnd() }
+            self.updateAutocomplete()
         case let .character(char):
             if modifiers.contains(.control) {
                 switch char.lowercased() {
@@ -280,8 +290,10 @@ public final class Editor: Component {
                     self.deleteWordBackwards()
                 case "a":
                     self.buffer = self.withMutatingBuffer { buf in buf.moveToLineStart() }
+                    self.updateAutocomplete()
                 case "e":
                     self.buffer = self.withMutatingBuffer { buf in buf.moveToLineEnd() }
+                    self.updateAutocomplete()
                 default:
                     self.insertCharacter(String(char))
                 }
@@ -308,39 +320,28 @@ public final class Editor: Component {
 
     private func insertNewLine() {
         self.buffer = self.withMutatingBuffer { buf in buf.insertNewLine() }
-        self.onChange?(self.getText())
+        self.textDidChange()
     }
 
     private func backspace() {
         self.buffer = self.withMutatingBuffer { buf in buf.backspace() }
-        self.onChange?(self.getText())
+        self.textDidChange()
     }
 
     private func deleteForward() {
         self.buffer = self.withMutatingBuffer { buf in buf.deleteForward() }
-        self.onChange?(self.getText())
+        self.textDidChange()
     }
 
     private func deleteWordForward() {
         self.buffer = self.withMutatingBuffer { buf in
             buf.deleteWordForward(isBoundary: self.isBoundary)
         }
-        self.onChange?(self.getText())
-    }
-
-    private func moveCursor(lineDelta: Int, columnDelta: Int) {
-        self.buffer = self.withMutatingBuffer { buf in buf.moveCursor(lineDelta: lineDelta, columnDelta: columnDelta) }
+        self.textDidChange()
     }
 
     private func submit() {
-        var text = self.getText().trimmingCharacters(in: .whitespacesAndNewlines)
-        for (id, paste) in self.pastes {
-            let pattern = "\\[paste #\(id)(?: [^\\]]+)?\\]"
-            if let regex = try? NSRegularExpression(pattern: pattern, options: []) {
-                let range = NSRange(location: 0, length: text.utf16.count)
-                text = regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: paste)
-            }
-        }
+        let text = self.expandPasteMarkers(in: self.getText()).trimmingCharacters(in: .whitespacesAndNewlines)
         self.buffer = EditorBuffer()
         self.pastes.removeAll()
         self.pasteCounter = 0
@@ -352,19 +353,19 @@ public final class Editor: Component {
 
     private func deleteToStartOfLine() {
         self.buffer = self.withMutatingBuffer { buf in buf.deleteToStartOfLine() }
-        self.onChange?(self.getText())
+        self.textDidChange()
     }
 
     private func deleteToEndOfLine() {
         self.buffer = self.withMutatingBuffer { buf in buf.deleteToEndOfLine() }
-        self.onChange?(self.getText())
+        self.textDidChange()
     }
 
     private func deleteWordBackwards() {
         self.buffer = self.withMutatingBuffer { buf in
             buf.deleteWordBackwards(isBoundary: self.isBoundary)
         }
-        self.onChange?(self.getText())
+        self.textDidChange()
     }
 
     private func moveByWord(_ direction: Int) {
@@ -386,19 +387,8 @@ public final class Editor: Component {
 
     private func handlePaste(_ text: String) {
         self.historyIndex = -1
-        let normalized = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
-        let spacesExpanded = normalized.replacingOccurrences(of: "\t", with: "    ")
-        var sanitized = spacesExpanded.reduce(into: "") { partial, char in
-            if char == "\n" {
-                partial.append(char)
-                return
-            }
-            // Keep any printable Unicode character; drop control chars (< 0x20).
-            let hasControl = char.unicodeScalars.contains { $0.value < 32 }
-            if !hasControl {
-                partial.append(char)
-            }
-        }
+        self.cancelAutocomplete()
+        var sanitized = PasteSanitizer.sanitize(text, allowsNewlines: true)
 
         // If pasting a file path and the character before the cursor is a word character, prepend a space.
         if let first = sanitized.first,
@@ -423,15 +413,13 @@ public final class Editor: Component {
             } else {
                 "[paste #\(self.pasteCounter) \(sanitized.count) chars]"
             }
-            for char in marker {
-                self.insertCharacter(String(char))
-            }
+            self.buffer = self.withMutatingBuffer { buf in buf.insertCharacter(marker) }
+            self.textDidChange(refreshAutocomplete: false)
             return
         }
         if lines.count == 1 {
-            for char in sanitized {
-                self.insertCharacter(String(char))
-            }
+            self.buffer = self.withMutatingBuffer { buf in buf.insertCharacter(sanitized) }
+            self.textDidChange(refreshAutocomplete: false)
             return
         }
         let currentLine = self.buffer.lines[self.buffer.cursorLine]
@@ -452,7 +440,43 @@ public final class Editor: Component {
                 buf.cursorCol = String(last).count
             }
         }
+        self.textDidChange(refreshAutocomplete: false)
+    }
+
+    private func textDidChange(refreshAutocomplete: Bool = true) {
+        self.synchronizePasteRegistry()
         self.onChange?(self.getText())
+        if refreshAutocomplete {
+            self.updateAutocomplete()
+        }
+    }
+
+    private func synchronizePasteRegistry() {
+        guard !self.pastes.isEmpty else { return }
+        let text = self.getText()
+        self.pastes = self.pastes.filter { id, _ in
+            guard let regex = Self.pasteMarkerRegex(id: id) else { return false }
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            return regex.firstMatch(in: text, range: range) != nil
+        }
+    }
+
+    private func expandPasteMarkers(in text: String) -> String {
+        var result = text
+        for (id, paste) in self.pastes.sorted(by: { $0.key < $1.key }) {
+            guard let regex = Self.pasteMarkerRegex(id: id) else { continue }
+            let range = NSRange(result.startIndex..<result.endIndex, in: result)
+            for match in regex.matches(in: result, range: range).reversed() {
+                guard let markerRange = Range(match.range, in: result) else { continue }
+                result.replaceSubrange(markerRange, with: paste)
+            }
+        }
+        return result
+    }
+
+    private static func pasteMarkerRegex(id: Int) -> NSRegularExpression? {
+        let pattern = "\\[paste #\(id)(?: \\+\\d+ lines| \\d+ chars)?\\]"
+        return try? NSRegularExpression(pattern: pattern)
     }
 
     /// Helper to mutate the value-type buffer while keeping `Editor` reference semantics.

--- a/Sources/TauTUI/Components/Input.swift
+++ b/Sources/TauTUI/Components/Input.swift
@@ -206,9 +206,7 @@ public final class Input: Component {
     }
 
     private func cleanedPaste(_ text: String) -> String {
-        text.replacingOccurrences(of: "\r\n", with: "")
-            .replacingOccurrences(of: "\n", with: "")
-            .replacingOccurrences(of: "\r", with: "")
+        PasteSanitizer.sanitize(text, allowsNewlines: false)
     }
 
     private func windowedValue(available: Int) -> (String, Int) {

--- a/Sources/TauTUI/Terminal/Terminal.swift
+++ b/Sources/TauTUI/Terminal/Terminal.swift
@@ -86,9 +86,11 @@ public final class ProcessTerminal: Terminal {
     private var rawModeEnabled = false
     private var terminalModesEnabled = false
 
+    private var pendingUTF8Bytes: [UInt8] = []
     private var pendingInput = ""
     private var isInBracketedPaste = false
     private var pasteBuffer = ""
+    private var escapeFlushWorkItem: DispatchWorkItem?
 
     /// Emit `.raw` events for debugging/inspection (e.g. KeyTester).
     /// Off by default because `.key`/`.paste` already cover functional input.
@@ -123,7 +125,17 @@ public final class ProcessTerminal: Terminal {
     func parseForTests(_ raw: String) -> [TerminalInput] {
         var captured: [TerminalInput] = []
         self.inputHandler = { captured.append($0) }
-        self.handleRawChunk(raw)
+        self.handleRawBytes(Array(raw.utf8))
+        return captured
+    }
+
+    /// Testing helper: parse byte chunks exactly as the descriptor reader receives them.
+    func parseBytesForTests(_ chunks: [[UInt8]]) -> [TerminalInput] {
+        var captured: [TerminalInput] = []
+        self.inputHandler = { captured.append($0) }
+        for chunk in chunks {
+            self.handleRawBytes(chunk)
+        }
         return captured
     }
 
@@ -157,9 +169,7 @@ public final class ProcessTerminal: Terminal {
                 }
             }
             guard byteCount > 0 else { return }
-            if let string = String(bytes: buffer.prefix(byteCount), encoding: .utf8) {
-                self.handleRawChunk(string)
-            }
+            self.handleRawBytes(Array(buffer.prefix(byteCount)))
         }
         source.resume()
         self.stdinSource = source
@@ -188,6 +198,9 @@ public final class ProcessTerminal: Terminal {
 
         self.inputHandler = nil
         self.resizeHandler = nil
+        self.escapeFlushWorkItem?.cancel()
+        self.escapeFlushWorkItem = nil
+        self.pendingUTF8Bytes.removeAll(keepingCapacity: false)
         self.pendingInput.removeAll(keepingCapacity: false)
         self.pasteBuffer.removeAll(keepingCapacity: false)
         self.isInBracketedPaste = false
@@ -257,8 +270,64 @@ public final class ProcessTerminal: Terminal {
 
     // MARK: - Input parsing
 
+    private func handleRawBytes(_ bytes: [UInt8]) {
+        guard !bytes.isEmpty else { return }
+        self.pendingUTF8Bytes.append(contentsOf: bytes)
+
+        let prefixLength = self.completeUTF8PrefixLength()
+        guard prefixLength > 0 else { return }
+
+        // Malformed bytes intentionally decode as replacement characters so one bad byte
+        // cannot stall the stream behind it.
+        // swiftlint:disable:next optional_data_string_conversion
+        let decoded = String(decoding: self.pendingUTF8Bytes.prefix(prefixLength), as: UTF8.self)
+        self.pendingUTF8Bytes.removeFirst(prefixLength)
+        self.handleRawChunk(decoded)
+    }
+
+    /// Returns the byte count that can be decoded without consuming a trailing partial scalar.
+    private func completeUTF8PrefixLength() -> Int {
+        var index = 0
+        while index < self.pendingUTF8Bytes.count {
+            let byte = self.pendingUTF8Bytes[index]
+            let sequenceLength: Int
+            switch byte {
+            case 0x00...0x7F:
+                sequenceLength = 1
+            case 0xC2...0xDF:
+                sequenceLength = 2
+            case 0xE0...0xEF:
+                sequenceLength = 3
+            case 0xF0...0xF4:
+                sequenceLength = 4
+            default:
+                // Decode malformed standalone bytes as replacement characters instead of
+                // retaining them forever and blocking all subsequent terminal input.
+                index += 1
+                continue
+            }
+
+            guard index + sequenceLength <= self.pendingUTF8Bytes.count else {
+                return index
+            }
+
+            let continuationStart = index + 1
+            let hasValidContinuations = continuationStart == index + sequenceLength ||
+                self.pendingUTF8Bytes[continuationStart..<(index + sequenceLength)]
+                .allSatisfy { $0 & 0xC0 == 0x80 }
+            if hasValidContinuations {
+                index += sequenceLength
+            } else {
+                index += 1
+            }
+        }
+        return index
+    }
+
     fileprivate func handleRawChunk(_ chunk: String) {
         guard !chunk.isEmpty else { return }
+        self.escapeFlushWorkItem?.cancel()
+        self.escapeFlushWorkItem = nil
         if self.emitsRawInputEvents {
             self.inputHandler?(.raw(chunk))
         }
@@ -282,8 +351,14 @@ public final class ProcessTerminal: Terminal {
                     self.pasteBuffer.removeAll(keepingCapacity: false)
                     continue
                 } else {
-                    self.pasteBuffer.append(self.pendingInput)
-                    self.pendingInput.removeAll(keepingCapacity: false)
+                    // A descriptor read may split the paste terminator at any byte. Retain
+                    // the longest possible delimiter prefix and commit only safe content.
+                    let retainedCount = self.trailingPasteEndPrefixLength()
+                    let contentCount = self.pendingInput.count - retainedCount
+                    if contentCount > 0 {
+                        self.pasteBuffer.append(String(self.pendingInput.prefix(contentCount)))
+                        self.pendingInput.removeFirstCharacters(contentCount)
+                    }
                     return
                 }
             }
@@ -322,9 +397,41 @@ public final class ProcessTerminal: Terminal {
                 continue
             }
 
+            if self.pendingInput.first == "\u{001B}" {
+                // CSI, SS3, paste, and Meta sequences may span descriptor reads. Delay a
+                // lone/incomplete ESC briefly so a real Escape key still resolves.
+                self.scheduleIncompleteEscapeFlush()
+                return
+            }
+
             let char = self.pendingInput.removeFirst()
             self.handleCharacter(char)
         }
+    }
+
+    private func trailingPasteEndPrefixLength() -> Int {
+        let maxLength = min(self.pendingInput.count, Self.bracketedPasteEnd.count - 1)
+        guard maxLength > 0 else { return 0 }
+        for length in stride(from: maxLength, through: 1, by: -1)
+            where Self.bracketedPasteEnd.hasPrefix(self.pendingInput.suffix(length))
+        {
+            return length
+        }
+        return 0
+    }
+
+    private func scheduleIncompleteEscapeFlush() {
+        guard self.escapeFlushWorkItem == nil else { return }
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.escapeFlushWorkItem = nil
+            guard self.pendingInput.first == "\u{001B}" else { return }
+            let escape = self.pendingInput.removeFirst()
+            self.handleCharacter(escape)
+            self.processPendingInput()
+        }
+        self.escapeFlushWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(30), execute: workItem)
     }
 
     private func handleCharacter(_ char: Character) {

--- a/Sources/TauTUI/Utilities/AnsiStyling.swift
+++ b/Sources/TauTUI/Utilities/AnsiStyling.swift
@@ -39,10 +39,9 @@ public enum AnsiStyling {
 
         public func apply(_ text: String) -> String {
             // Apply background, reapplying after any full reset (0m) or background reset (49m).
-            var withBg = self.start + text + self.end
-            withBg = withBg.replacingOccurrences(of: "\u{001B}[0m", with: "\u{001B}[0m" + self.start)
-            withBg = withBg.replacingOccurrences(of: "\u{001B}[49m", with: "\u{001B}[49m" + self.start)
-            return withBg
+            var styledText = text.replacingOccurrences(of: "\u{001B}[0m", with: "\u{001B}[0m" + self.start)
+            styledText = styledText.replacingOccurrences(of: self.end, with: self.end + self.start)
+            return self.start + styledText + self.end
         }
     }
 }

--- a/Sources/TauTUI/Utilities/AnsiWrapping.swift
+++ b/Sources/TauTUI/Utilities/AnsiWrapping.swift
@@ -9,7 +9,10 @@ public enum AnsiWrapping {
         guard width > 0 else { return [""] }
         guard !text.isEmpty else { return [""] }
 
-        let normalized = Ansi.normalizeTabs(text, spacesPerTab: tabSize)
+        let normalizedLineEndings = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        let normalized = Ansi.normalizeTabs(normalizedLineEndings, spacesPerTab: tabSize)
         let inputLines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
 
         var result: [String] = []

--- a/Sources/TauTUI/Utilities/PasteSanitizer.swift
+++ b/Sources/TauTUI/Utilities/PasteSanitizer.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum PasteSanitizer {
+    static func sanitize(_ text: String, allowsNewlines: Bool, tabWidth: Int = 4) -> String {
+        let normalized = text
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .replacingOccurrences(of: "\t", with: String(repeating: " ", count: max(0, tabWidth)))
+
+        return normalized.unicodeScalars.reduce(into: "") { result, scalar in
+            if scalar == "\n" {
+                if allowsNewlines {
+                    result.unicodeScalars.append(scalar)
+                }
+            } else if !CharacterSet.controlCharacters.contains(scalar) {
+                result.unicodeScalars.append(scalar)
+            }
+        }
+    }
+}

--- a/Tests/TauTUITests/AnsiWrappingTests.swift
+++ b/Tests/TauTUITests/AnsiWrappingTests.swift
@@ -22,6 +22,12 @@ struct AnsiWrappingTests {
     }
 
     @Test
+    func `normalizes carriage return line endings`() {
+        let wrapped = AnsiWrapping.wrapText("one\r\ntwo\rthree", width: 20)
+        #expect(wrapped == ["one", "two", "three"])
+    }
+
+    @Test
     func `apply background pads and keeps resets`() {
         let bg = AnsiStyling.Background.rgb(0, 255, 0)
         let line = "\u{001B}[1mhello\u{001B}[0m world"
@@ -29,6 +35,17 @@ struct AnsiWrappingTests {
         #expect(VisibleWidth.measure(result) == 20)
         // Background should be reapplied after reset
         #expect(result.contains(bg.start))
+        #expect(result.hasSuffix(bg.end))
+        #expect(!result.hasSuffix(bg.start))
+    }
+
+    @Test
+    func `background reapplies only after internal resets`() {
+        let background = AnsiStyling.Background.rgb(1, 2, 3)
+        let result = background.apply("one\u{001B}[0mtwo\u{001B}[49mthree")
+
+        #expect(result == background.start + "one\u{001B}[0m" + background.start + "two" + background.end +
+            background.start + "three" + background.end)
     }
 
     @Test

--- a/Tests/TauTUITests/EditorPasteTests.swift
+++ b/Tests/TauTUITests/EditorPasteTests.swift
@@ -42,6 +42,60 @@ struct EditorPasteTests {
     }
 
     @Test
+    func `paste expansion preserves replacement metacharacters`() {
+        let editor = Editor()
+        var submitted: String?
+        editor.onSubmit = { submitted = $0 }
+        let paste = String(repeating: "$1 \\path\n", count: 12)
+
+        editor.handle(input: .paste(paste))
+        editor.handle(input: .key(.enter))
+
+        #expect(submitted == paste.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    @Test
+    func `set text clears hidden paste state`() {
+        let editor = Editor()
+        var submitted: String?
+        editor.onSubmit = { submitted = $0 }
+        let paste = Array(repeating: "secret", count: 12).joined(separator: "\n")
+
+        editor.handle(input: .paste(paste))
+        let marker = editor.getText()
+        editor.setText(marker)
+        editor.handle(input: .key(.enter))
+
+        #expect(submitted == marker)
+    }
+
+    @Test
+    func `editing a marker drops its hidden paste`() {
+        let editor = Editor()
+        let paste = Array(repeating: "payload", count: 12).joined(separator: "\n")
+
+        editor.handle(input: .paste(paste))
+        #expect(editor.pastes.count == 1)
+        editor.handle(input: .key(.backspace))
+
+        #expect(editor.pastes.isEmpty)
+    }
+
+    @Test
+    func `pastes mutate the editor once without querying autocomplete`() {
+        let editor = Editor()
+        let provider = CountingAutocompleteProvider()
+        editor.setAutocompleteProvider(provider)
+        var changes = 0
+        editor.onChange = { _ in changes += 1 }
+
+        editor.handle(input: .paste(String(repeating: "x", count: 999)))
+
+        #expect(changes == 1)
+        #expect(provider.queryCount == 0)
+    }
+
+    @Test
     func `paste prepends space for file paths after word character`() {
         let editor = Editor()
         editor.setText("hello")
@@ -49,5 +103,28 @@ struct EditorPasteTests {
         editor.handle(input: .paste("/tmp/file.txt"))
 
         #expect(editor.getText() == "hello /tmp/file.txt")
+    }
+}
+
+private final class CountingAutocompleteProvider: AutocompleteProvider {
+    var queryCount = 0
+
+    func getSuggestions(
+        lines: [String],
+        cursorLine: Int,
+        cursorCol: Int) -> AutocompleteSuggestion?
+    {
+        self.queryCount += 1
+        return nil
+    }
+
+    func applyCompletion(
+        lines: [String],
+        cursorLine: Int,
+        cursorCol: Int,
+        item: AutocompleteItem,
+        prefix: String) -> (lines: [String], cursorLine: Int, cursorCol: Int)
+    {
+        (lines, cursorLine, cursorCol)
     }
 }

--- a/Tests/TauTUITests/EditorTests.swift
+++ b/Tests/TauTUITests/EditorTests.swift
@@ -18,6 +18,7 @@ private func type(_ text: String, into editor: Editor) {
 
 private final class StubAutocompleteProvider: AutocompleteProvider {
     var suggestion: AutocompleteSuggestion?
+    var suggestionForInput: (([String], Int, Int) -> AutocompleteSuggestion?)?
     var triggerFileCompletion = true
 
     func getSuggestions(
@@ -25,7 +26,7 @@ private final class StubAutocompleteProvider: AutocompleteProvider {
         cursorLine: Int,
         cursorCol: Int) -> AutocompleteSuggestion?
     {
-        self.suggestion
+        self.suggestionForInput?(lines, cursorLine, cursorCol) ?? self.suggestion
     }
 
     func applyCompletion(
@@ -302,10 +303,12 @@ struct EditorTests {
     @Test
     func `paste filters control characters`() {
         let editor = Editor()
-        editor.handle(input: .paste("\tcolumn\u{0007}\nline"))
+        editor.handle(input: .paste("\tcolumn\u{0007}\u{007F}\u{0085}\nline"))
         let text = editor.getText()
         #expect(text.contains("    column"))
         #expect(!text.contains("\u{0007}"))
+        #expect(!text.contains("\u{007F}"))
+        #expect(!text.contains("\u{0085}"))
     }
 
     @Test
@@ -323,6 +326,26 @@ struct EditorTests {
 
         editor.handle(input: .key(.escape))
         let hidden = editor.render(width: 20)
+        #expect(showing.count > hidden.count)
+    }
+
+    @Test
+    func `cursor movement refreshes autocomplete`() {
+        let provider = StubAutocompleteProvider()
+        provider.suggestionForInput = { _, _, cursorCol in
+            guard cursorCol == 2 else { return nil }
+            return AutocompleteSuggestion(
+                items: [AutocompleteItem(value: "alpha", label: "alpha", description: nil)],
+                prefix: "/a")
+        }
+        let editor = Editor()
+        editor.setAutocompleteProvider(provider)
+
+        type("/a", into: editor)
+        let showing = editor.render(width: 20)
+        editor.handle(input: .key(.arrowLeft))
+        let hidden = editor.render(width: 20)
+
         #expect(showing.count > hidden.count)
     }
 

--- a/Tests/TauTUITests/InputTests.swift
+++ b/Tests/TauTUITests/InputTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import TauTUI
 
@@ -33,6 +34,16 @@ struct InputTests {
 
         input.handle(input: .raw("\u{001B}[A"))
         #expect(input.value == "hello worldmorelines")
+    }
+
+    @Test
+    func `paste removes terminal control sequences and preserves unicode`() {
+        let input = Input()
+
+        input.handle(input: .paste("\u{001B}]0;owned\u{0007}\u{001B}[31mhello\u{007F}\u{0085}\t😀\nworld"))
+
+        #expect(input.value == "]0;owned[31mhello    😀world")
+        #expect(!input.value.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains))
     }
 
     @Test

--- a/Tests/TauTUITests/TUITests.swift
+++ b/Tests/TauTUITests/TUITests.swift
@@ -232,6 +232,94 @@ struct TUIRenderingTests {
     }
 
     @Test
+    func `CSI parsing survives every byte split`() {
+        let payload = Array("\u{001B}[1;3D".utf8)
+
+        for split in 0...payload.count {
+            let parser = ProcessTerminal()
+            let events = parser.parseBytesForTests([
+                Array(payload[..<split]),
+                Array(payload[split...]),
+            ])
+
+            #expect(events.count == 1, "split at byte \(split)")
+            guard events.count == 1,
+                  case let .key(.arrowLeft, modifiers) = events[0]
+            else {
+                Issue.record("expected Option-Left when split at byte \(split)")
+                continue
+            }
+            #expect(modifiers == [.option], "split at byte \(split)")
+        }
+    }
+
+    @Test
+    func `Kitty parsing survives every byte split`() {
+        let payload = Array("\u{001B}[119;5u".utf8)
+
+        for split in 0...payload.count {
+            let parser = ProcessTerminal()
+            let events = parser.parseBytesForTests([
+                Array(payload[..<split]),
+                Array(payload[split...]),
+            ])
+
+            #expect(events.count == 1, "split at byte \(split)")
+            guard events.count == 1,
+                  case let .key(.character("w"), modifiers) = events[0]
+            else {
+                Issue.record("expected Control-W when split at byte \(split)")
+                continue
+            }
+            #expect(modifiers == [.control], "split at byte \(split)")
+        }
+    }
+
+    @Test
+    func `bracketed paste delimiters survive every byte split`() {
+        let pasted = "hello 😀"
+        let payload = Array("\u{001B}[200~\(pasted)\u{001B}[201~".utf8)
+
+        for split in 0...payload.count {
+            let parser = ProcessTerminal()
+            let events = parser.parseBytesForTests([
+                Array(payload[..<split]),
+                Array(payload[split...]),
+            ])
+
+            #expect(events.count == 1, "split at byte \(split)")
+            guard events.count == 1, case let .paste(value) = events[0] else {
+                Issue.record("expected one paste event when split at byte \(split)")
+                continue
+            }
+            #expect(value == pasted, "split at byte \(split)")
+        }
+    }
+
+    @Test
+    func `UTF8 input survives every byte split`() {
+        let text = "Aé😀B"
+        let payload = Array(text.utf8)
+
+        for split in 0...payload.count {
+            let parser = ProcessTerminal()
+            let events = parser.parseBytesForTests([
+                Array(payload[..<split]),
+                Array(payload[split...]),
+            ])
+            let characters = events.compactMap { event -> Character? in
+                guard case let .key(.character(character), modifiers) = event,
+                      modifiers.isEmpty
+                else { return nil }
+                return character
+            }
+
+            #expect(events.count == text.count, "split at byte \(split)")
+            #expect(String(characters) == text, "split at byte \(split)")
+        }
+    }
+
+    @Test
     func `key event normalization line feed treats as enter`() {
         let parser = ProcessTerminal()
         let events = parser.parseForTests("\n")

--- a/docs/pitui-sync.md
+++ b/docs/pitui-sync.md
@@ -1,6 +1,25 @@
+# pi-tui sync log (Aug 11, 2026)
+
+Context: the current upstream checkout lives at `../oss/pi-mono` (`/Users/steipete/Projects/oss/pi-mono`) relative to this repo. Current `origin/main` inspected: `534bcbffb` on **2026-08-11**; the latest released TUI entry is **0.84.1 (2026-08-07)**.
+
+## Changes synchronized in TauTUI 0.2.2
+
+- Editor paste insertion is atomic, avoiding hundreds of intermediate `onChange` and autocomplete calls for an ordinary paste.
+- Editor and Input now share one Unicode-preserving paste sanitizer, eliminating divergent handling of terminal controls, tabs, and line endings.
+- `setText` and marker edits discard stale hidden paste payloads; submit expansion inserts `$` and backslashes literally instead of treating them as regular-expression replacement syntax.
+- Open autocomplete results re-query after cursor movement and destructive edits so accepting a suggestion cannot apply a result for an old cursor position.
+- ProcessTerminal now treats descriptor input as a byte stream, retaining split UTF-8 scalars, CSI/Kitty sequences, and bracketed-paste delimiters between reads.
+- Background styles now reapply only after internal resets and always terminate with their configured reset sequence.
+- ANSI-aware wrapping normalizes CRLF and CR line endings before layout.
+
+## Audited upstream changes not yet ported
+
+- The alternate-screen renderer, layout stacks, mouse selection, transcript navigation/search, and native Windows/Darwin input helpers are separate from TauTUI's current main-screen renderer and Peekaboo's usage, so they were intentionally not pulled into this focused dependency refresh.
+- Unicode word segmentation, terminal capability negotiation, OSC 8 hyperlinks, terminal color-scheme queries, configurable loader indicators, Markdown source-marker preservation, and LaTeX rendering remain useful future parity work. They should land as separately tested API changes rather than widening this editor-state fix.
+
 # pi-tui sync log (Dec 27, 2025)
 
-Context: upstream `pi-mono` checkout lives at `../../pi-mono` (`/Users/steipete/Projects/pi-mono`) relative to this repo. Current head inspected: `origin/main` at `04fa79e` as of **2025-12-27**. `packages/tui/CHANGELOG.md` latest entry: **0.29.0 (2025-12-25)**.
+Context: upstream `pi-mono` checkout then lived at `../../pi-mono` (`/Users/steipete/Projects/pi-mono`) relative to this repo. Head inspected: `origin/main` at `04fa79e` as of **2025-12-27**. `packages/tui/CHANGELOG.md` latest entry: **0.29.0 (2025-12-25)**.
 
 ## Notable upstream changes (TUI)
 - Auto-space before pasted file paths (prefix `/`, `~`, `.`) when cursor is after a word char.


### PR DESCRIPTION
## Summary

- preserve UTF-8 scalars, terminal key sequences, and bracketed-paste delimiters across descriptor read boundaries
- make editor paste state fail closed, insert pastes atomically, refresh autocomplete after movement/deletion, and share control-safe paste sanitization with Input
- stop ANSI backgrounds from leaking, normalize CR/CRLF wrapping, and remove a Swift 6.4 capture warning in ChatDemo
- refresh the pi-tui sync audit against current upstream

## Proof

- `swiftformat --lint . --config .swiftformat`
- `swiftlint --config .swiftlint.yml`
- `git diff --check`
- `swift build`
- `swift test --parallel` (167 tests)
- autoreview clean: no accepted/actionable findings
