### PR TITLE
fix: enforce renderer bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [0.2.2] - Unreleased
+- Markdown code blocks now wrap styled content and fences to the render width instead of violating TUI viewport invariants while streaming.
+- Image rendering now honors `maxHeightCells`, reducing width proportionally to preserve aspect ratio, and applies a bounded default height.
 - Editor pastes are now inserted atomically without per-character autocomplete work, stale hidden paste payloads are discarded when markers or editor text change, and payloads containing `$` or backslashes expand literally on submit.
 - Editor and Input now share one Unicode-preserving paste sanitizer that strips terminal control characters and normalizes tabs and line endings.
 - Open autocomplete suggestions now refresh after cursor movement and text deletion instead of applying results computed for a stale cursor position.

--- a/Sources/TauTUI/Autocomplete/Autocomplete.swift
+++ b/Sources/TauTUI/Autocomplete/Autocomplete.swift
@@ -173,11 +173,6 @@ public final class CombinedAutocompleteProvider: AutocompleteProvider {
         return item.value
     }
 
-    private func completionCursorOffset(for prefix: String, item: AutocompleteItem) -> Int {
-        let replacement = self.completionString(for: prefix, item: item)
-        return replacement.count
-    }
-
     private func slashCommandSuggestions(textBeforeCursor: String) -> AutocompleteSuggestion? {
         if let spaceIndex = textBeforeCursor.firstIndex(of: " ") {
             let commandName =

--- a/Sources/TauTUI/Components/Image.swift
+++ b/Sources/TauTUI/Components/Image.swift
@@ -57,6 +57,11 @@ public final class Image: Component {
         }
 
         let maxWidth = max(1, min(max(0, width - 2), self.options.maxWidthCells ?? 60))
+        let cellDimensions = TerminalImage.getCellDimensions()
+        let cellWidth = max(1, cellDimensions.widthPx)
+        let cellHeight = max(1, cellDimensions.heightPx)
+        let defaultMaxHeight = max(1, (maxWidth * cellWidth + cellHeight - 1) / cellHeight)
+        let maxHeight = self.options.maxHeightCells ?? defaultMaxHeight
 
         let caps = TerminalImage.getCapabilities()
         let lines: [String]
@@ -65,7 +70,7 @@ public final class Image: Component {
            let result = TerminalImage.renderImage(
                base64Data: self.base64Data,
                imageDimensions: self.dimensions,
-               options: .init(maxWidthCells: maxWidth))
+               options: .init(maxWidthCells: maxWidth, maxHeightCells: maxHeight))
         {
             var buffer: [String] = []
             buffer.reserveCapacity(result.rows)

--- a/Sources/TauTUI/Components/MarkdownComponent.swift
+++ b/Sources/TauTUI/Components/MarkdownComponent.swift
@@ -306,11 +306,15 @@ private final class Renderer {
     }
 
     private func renderCodeBlock(_ code: CodeBlock) {
-        self.lines.append(self.theme.codeBlockBorder("```\(code.language ?? "")"))
+        self.wrap(line: self.theme.codeBlockBorder("```\(code.language ?? "")"))
+        let indentWidth = min(2, max(0, self.maxWidth - 1))
+        let indent = String(repeating: " ", count: indentWidth)
+        let contentWidth = max(1, self.maxWidth - indentWidth)
         for line in code.code.split(separator: "\n", omittingEmptySubsequences: false) {
-            self.lines.append("  " + self.theme.codeBlock(String(line)))
+            let styled = self.theme.codeBlock(String(line))
+            self.lines.append(contentsOf: AnsiWrapping.wrapText(styled, width: contentWidth).map { indent + $0 })
         }
-        self.lines.append(self.theme.codeBlockBorder("```"))
+        self.wrap(line: self.theme.codeBlockBorder("```"))
         self.lines.append("")
     }
 

--- a/Sources/TauTUI/Terminal/TerminalImage.swift
+++ b/Sources/TauTUI/Terminal/TerminalImage.swift
@@ -123,6 +123,12 @@ public enum TerminalImage {
         self.storage.lock.unlock()
     }
 
+    static func setCapabilitiesForTests(_ capabilities: TerminalCapabilities) {
+        self.storage.lock.lock()
+        self.storage.cachedCapabilities = capabilities
+        self.storage.lock.unlock()
+    }
+
     public static func encodeKitty(
         base64Data: String,
         columns: Int? = nil,
@@ -192,20 +198,34 @@ public enum TerminalImage {
         targetWidthCells: Int,
         cellDimensions: CellDimensions = .init(widthPx: 9, heightPx: 18)) -> Int
     {
-        guard targetWidthCells > 0,
-              imageDimensions.widthPx > 0,
-              imageDimensions.heightPx > 0,
-              cellDimensions.widthPx > 0,
-              cellDimensions.heightPx > 0
-        else {
-            return 1
-        }
+        self.calculateImageCellSize(
+            imageDimensions: imageDimensions,
+            maxWidthCells: targetWidthCells,
+            cellDimensions: cellDimensions).rows
+    }
 
-        let targetWidthPx = targetWidthCells * cellDimensions.widthPx
-        let scale = Double(targetWidthPx) / Double(imageDimensions.widthPx)
-        let scaledHeightPx = Double(imageDimensions.heightPx) * scale
-        let rows = Int(ceil(scaledHeightPx / Double(cellDimensions.heightPx)))
-        return max(1, rows)
+    static func calculateImageCellSize(
+        imageDimensions: ImageDimensions,
+        maxWidthCells: Int,
+        maxHeightCells: Int? = nil,
+        cellDimensions: CellDimensions = .init(widthPx: 9, heightPx: 18)) -> (columns: Int, rows: Int)
+    {
+        let maxWidth = max(1, maxWidthCells)
+        let maxHeight = maxHeightCells.map { max(1, $0) }
+        let imageWidth = max(1, imageDimensions.widthPx)
+        let imageHeight = max(1, imageDimensions.heightPx)
+        let cellWidth = max(1, cellDimensions.widthPx)
+        let cellHeight = max(1, cellDimensions.heightPx)
+
+        let widthScale = Double(maxWidth * cellWidth) / Double(imageWidth)
+        let heightScale = maxHeight.map { Double($0 * cellHeight) / Double(imageHeight) } ?? widthScale
+        let scale = min(widthScale, heightScale)
+        let columns = Int(ceil(Double(imageWidth) * scale / Double(cellWidth)))
+        let rows = Int(ceil(Double(imageHeight) * scale / Double(cellHeight)))
+
+        return (
+            columns: max(1, min(maxWidth, columns)),
+            rows: max(1, maxHeight.map { min($0, rows) } ?? rows))
     }
 
     public static func getImageDimensions(base64Data: String, mimeType: String) -> ImageDimensions? {
@@ -231,24 +251,24 @@ public enum TerminalImage {
         let caps = self.getCapabilities()
         guard let images = caps.images else { return nil }
 
-        let maxWidth = options.maxWidthCells ?? 80
-        let rows = self.calculateImageRows(
+        let size = self.calculateImageCellSize(
             imageDimensions: imageDimensions,
-            targetWidthCells: maxWidth,
+            maxWidthCells: options.maxWidthCells ?? 80,
+            maxHeightCells: options.maxHeightCells,
             cellDimensions: self.getCellDimensions())
 
         switch images {
         case .kitty:
-            let sequence = self.encodeKitty(base64Data: base64Data, columns: maxWidth, rows: rows)
-            return (sequence: sequence, rows: rows)
+            let sequence = self.encodeKitty(base64Data: base64Data, columns: size.columns, rows: size.rows)
+            return (sequence: sequence, rows: size.rows)
         case .iterm2:
             let sequence = self.encodeITerm2(
                 base64Data: base64Data,
-                width: "\(maxWidth)",
+                width: "\(size.columns)",
                 height: "auto",
                 preserveAspectRatio: options.preserveAspectRatio ?? true,
                 inline: true)
-            return (sequence: sequence, rows: rows)
+            return (sequence: sequence, rows: size.rows)
         }
     }
 

--- a/Tests/TauTUITests/MarkdownCodeTests.swift
+++ b/Tests/TauTUITests/MarkdownCodeTests.swift
@@ -24,4 +24,19 @@ struct MarkdownCodeTests {
         #expect(lines.contains(where: { $0.contains("│ quoted line") }))
         #expect(lines.contains(where: { $0.contains("│ second") || $0.contains("│ quoted line second") }))
     }
+
+    @Test
+    func `streaming code blocks stay within the render width`() {
+        let component = MarkdownComponent(
+            text: "```swift\n\(String(repeating: "abcdefghij", count: 8))",
+            padding: .init(horizontal: 0, vertical: 0))
+
+        let partial = component.render(width: 20)
+        #expect(partial.allSatisfy { VisibleWidth.measure($0) <= 20 })
+
+        component.text += "\nprint(\"done\")\n```"
+        let completed = component.render(width: 20)
+        #expect(completed.allSatisfy { VisibleWidth.measure($0) <= 20 })
+        #expect(completed.map { Ansi.stripCodes($0) }.contains(where: { $0.contains("done") }))
+    }
 }

--- a/Tests/TauTUITests/TerminalImageTests.swift
+++ b/Tests/TauTUITests/TerminalImageTests.swift
@@ -74,4 +74,44 @@ struct TerminalImageTests {
         #expect(jpegDims?.widthPx == 32)
         #expect(jpegDims?.heightPx == 16)
     }
+
+    @Test
+    func `max height reduces image width while preserving aspect ratio`() {
+        let size = TerminalImage.calculateImageCellSize(
+            imageDimensions: .init(widthPx: 10, heightPx: 100),
+            maxWidthCells: 10,
+            maxHeightCells: 5,
+            cellDimensions: .init(widthPx: 10, heightPx: 10))
+
+        #expect(size.columns == 1)
+        #expect(size.rows == 5)
+    }
+
+    @Test
+    func `image component honors explicit max height`() {
+        TerminalImage.setCapabilitiesForTests(.init(images: .kitty, trueColor: true, hyperlinks: true))
+        TerminalImage.setCellDimensions(.init(widthPx: 10, heightPx: 10))
+        defer {
+            TerminalImage.resetCapabilitiesCache()
+            TerminalImage.setCellDimensions(.init(widthPx: 9, heightPx: 18))
+        }
+
+        let image = Image(
+            base64Data: "AAAA",
+            mimeType: "image/png",
+            options: .init(maxWidthCells: 10, maxHeightCells: 3),
+            dimensions: .init(widthPx: 10, heightPx: 100))
+        let lines = image.render(width: 12)
+
+        #expect(lines.count == 3)
+        #expect(lines.joined().contains("c=1,r=3"))
+
+        TerminalImage.setCapabilitiesForTests(.init(images: .iterm2, trueColor: true, hyperlinks: true))
+        let iterm = TerminalImage.renderImage(
+            base64Data: "AAAA",
+            imageDimensions: .init(widthPx: 10, heightPx: 100),
+            options: .init(maxWidthCells: 10, maxHeightCells: 3))
+        #expect(iterm?.rows == 3)
+        #expect(iterm?.sequence.contains("width=1;height=auto") == true)
+    }
 }

--- a/docs/pitui-sync.md
+++ b/docs/pitui-sync.md
@@ -4,6 +4,8 @@ Context: the current upstream checkout lives at `../oss/pi-mono` (`/Users/steipe
 
 ## Changes synchronized in TauTUI 0.2.2
 
+- Markdown code blocks now stay within the render width, including incomplete fences updated while content streams.
+- Image sizing now applies both width and height bounds while preserving aspect ratio, including the upstream square-pixel default height.
 - Editor paste insertion is atomic, avoiding hundreds of intermediate `onChange` and autocomplete calls for an ordinary paste.
 - Editor and Input now share one Unicode-preserving paste sanitizer, eliminating divergent handling of terminal controls, tabs, and line endings.
 - `setText` and marker edits discard stale hidden paste payloads; submit expansion inserts `$` and backslashes literally instead of treating them as regular-expression replacement syntax.


### PR DESCRIPTION
## Summary

- wrap styled Markdown code fences and content to the declared render width, including incomplete streaming fences
- apply both width and height image bounds while preserving aspect ratio for Kitty and iTerm2 rendering
- give `Image` the upstream square-pixel default height bound and remove one unused autocomplete helper

## Proof

- `swiftformat --lint . --config .swiftformat`
- `swiftlint --config .swiftlint.yml`
- `git diff --check`
- `swift build`
- `swift test --parallel` (170 tests)
- autoreview clean: no accepted/actionable findings
