### PR TITLE
fix: release input after malformed UTF-8 prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - Editor pastes are now inserted atomically without per-character autocomplete work, stale hidden paste payloads are discarded when markers or editor text change, and payloads containing `$` or backslashes expand literally on submit.
 - Editor and Input now share one Unicode-preserving paste sanitizer that strips terminal control characters and normalizes tabs and line endings.
 - Open autocomplete suggestions now refresh after cursor movement and text deletion instead of applying results computed for a stale cursor position.
-- ProcessTerminal now preserves split UTF-8 scalars, CSI/Kitty key sequences, and bracketed-paste delimiters across arbitrary descriptor read boundaries.
+- ProcessTerminal now preserves split UTF-8 scalars, CSI/Kitty key sequences, and bracketed-paste delimiters across arbitrary descriptor read boundaries without letting malformed UTF-8 prefixes stall subsequent input.
 - Background styles now always finish with a reset instead of leaking their color into later terminal output.
 - ANSI-aware wrapping now treats CRLF and CR as line endings, preserving line boundaries from cross-platform terminal output.
 - ChatDemo no longer retains its view model through the editor submit callback and builds without Swift 6.4 capture warnings.

--- a/Sources/TauTUI/Terminal/Terminal.swift
+++ b/Sources/TauTUI/Terminal/Terminal.swift
@@ -307,19 +307,21 @@ public final class ProcessTerminal: Terminal {
                 continue
             }
 
-            guard index + sequenceLength <= self.pendingUTF8Bytes.count else {
-                return index
+            let continuationStart = index + 1
+            let sequenceEnd = index + sequenceLength
+            let availableEnd = min(sequenceEnd, self.pendingUTF8Bytes.count)
+            let hasValidContinuations = continuationStart == availableEnd ||
+                self.pendingUTF8Bytes[continuationStart..<availableEnd]
+                .allSatisfy { $0 & 0xC0 == 0x80 }
+            if !hasValidContinuations {
+                index += 1
+                continue
             }
 
-            let continuationStart = index + 1
-            let hasValidContinuations = continuationStart == index + sequenceLength ||
-                self.pendingUTF8Bytes[continuationStart..<(index + sequenceLength)]
-                .allSatisfy { $0 & 0xC0 == 0x80 }
-            if hasValidContinuations {
-                index += sequenceLength
-            } else {
-                index += 1
+            guard sequenceEnd <= self.pendingUTF8Bytes.count else {
+                return index
             }
+            index = sequenceEnd
         }
         return index
     }

--- a/Tests/TauTUITests/TUITests.swift
+++ b/Tests/TauTUITests/TUITests.swift
@@ -320,6 +320,58 @@ struct TUIRenderingTests {
     }
 
     @Test
+    func `malformed UTF8 lead does not suppress following ASCII`() {
+        let parser = ProcessTerminal()
+        let events = parser.parseBytesForTests([[0xE2, 0x41]])
+        let characters = events.compactMap { event -> Character? in
+            guard case let .key(.character(character), modifiers) = event,
+                  modifiers.isEmpty
+            else { return nil }
+            return character
+        }
+
+        #expect(String(characters) == "\u{FFFD}A")
+    }
+
+    @Test
+    func `malformed UTF8 prefix releases ASCII across read boundaries`() {
+        let chunks: [[[UInt8]]] = [
+            [[0xE2], [0x41]],
+            [[0xF0], [0x41]],
+            [[0xF0, 0x9F], [0x41]],
+        ]
+
+        for chunks in chunks {
+            let parser = ProcessTerminal()
+            let events = parser.parseBytesForTests(chunks)
+            let characters = events.compactMap { event -> Character? in
+                guard case let .key(.character(character), modifiers) = event,
+                      modifiers.isEmpty
+                else { return nil }
+                return character
+            }
+
+            #expect(String(characters) == "\u{FFFD}A", "chunks: \(chunks)")
+        }
+    }
+
+    @Test
+    func `valid partial UTF8 scalar remains buffered at a read boundary`() {
+        let parser = ProcessTerminal()
+
+        #expect(parser.parseBytesForTests([[0xE2, 0x82]]).isEmpty)
+
+        let events = parser.parseBytesForTests([[0xAC, 0x41]])
+        let characters = events.compactMap { event -> Character? in
+            guard case let .key(.character(character), modifiers) = event,
+                  modifiers.isEmpty
+            else { return nil }
+            return character
+        }
+        #expect(String(characters) == "€A")
+    }
+
+    @Test
     func `key event normalization line feed treats as enter`() {
         let parser = ProcessTerminal()
         let events = parser.parseForTests("\n")


### PR DESCRIPTION
## Summary

- validate continuation bytes that have already arrived before treating a UTF-8 scalar as merely incomplete
- release malformed leading bytes so subsequent ASCII input is decoded immediately while valid partial scalars remain buffered
- cover same-read and split-read malformed prefixes, valid boundary retention, and update the existing Unreleased terminal note

## Testing

- `swift test --parallel` (172 TauTUI tests and 1 external-client test passed)
- `swift test --filter UTF8` (4 tests passed)
- `swiftformat --lint . --config .swiftformat`
- `swiftlint --config .swiftlint.yml` (0 violations)
- source-blind behavior validation (5/5 contract checks passed)
- autoreview clean with no accepted or actionable findings
