### PR TITLE
fix: redraw on terminal height changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Input scrolling now uses terminal columns so CJK, fullwidth, and emoji text cannot overflow the viewport.
 - ProcessTerminal shutdown is now idempotent and no longer writes terminal-mode resets when the terminal was never started.
 - TUI sessions no longer render after shutdown, reuse stale render state after restart, or leave old rows visible when content becomes empty.
+- Height-only terminal resizes now trigger a full redraw so the main-screen viewport stays aligned.
 
 ## [0.2.1] - 2026-07-15
 - TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper. Thanks @devYRPauli.

--- a/Sources/TauTUI/Core/TUI.swift
+++ b/Sources/TauTUI/Core/TUI.swift
@@ -16,6 +16,7 @@ public final class TUI: Container {
 
     private var previousLines: [String] = []
     private var previousWidth: Int = 0
+    private var previousHeight: Int = 0
     private var cursorRow: Int = 0
     private var renderRequested = false
     private var isRunning = false
@@ -59,6 +60,7 @@ public final class TUI: Container {
         self.renderRequested = false
         self.previousLines = []
         self.previousWidth = 0
+        self.previousHeight = 0
         self.cursorRow = 0
         self.terminal.showCursor()
         self.terminal.stop()
@@ -128,25 +130,19 @@ public final class TUI: Container {
             if !self.previousLines.isEmpty {
                 self.writePartialRender(lines: [""], from: 0)
             }
-            self.previousLines = []
-            self.previousWidth = width
-            self.cursorRow = 0
+            self.recordRenderState(lines: [], width: width, height: height)
             return
         }
 
         if self.previousLines.isEmpty {
             self.writeFullRender(newLines)
-            self.previousLines = newLines
-            self.previousWidth = width
-            self.cursorRow = newLines.count - 1
+            self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
 
-        if self.previousWidth != width {
+        if self.previousWidth != width || self.previousHeight != height {
             self.writeFullRender(newLines, clear: true)
-            self.previousLines = newLines
-            self.previousWidth = width
-            self.cursorRow = newLines.count - 1
+            self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
 
@@ -157,16 +153,19 @@ public final class TUI: Container {
         let viewportTop = self.cursorRow - height + 1
         if diffRange.lowerBound < viewportTop {
             self.writeFullRender(newLines, clear: true)
-            self.previousLines = newLines
-            self.previousWidth = width
-            self.cursorRow = newLines.count - 1
+            self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
 
         self.writePartialRender(lines: newLines, from: diffRange.lowerBound)
-        self.previousLines = newLines
+        self.recordRenderState(lines: newLines, width: width, height: height)
+    }
+
+    private func recordRenderState(lines: [String], width: Int, height: Int) {
+        self.previousLines = lines
         self.previousWidth = width
-        self.cursorRow = newLines.count - 1
+        self.previousHeight = height
+        self.cursorRow = max(0, lines.count - 1)
     }
 
     private func computeDiffRange(old: [String], new: [String]) -> Range<Int>? {

--- a/Tests/TauTUITests/TUITests.swift
+++ b/Tests/TauTUITests/TUITests.swift
@@ -55,6 +55,22 @@ struct TUIRenderingTests {
     }
 
     @MainActor @Test
+    func `height resize forces full render and clear`() throws {
+        let terminal = VirtualTerminal(columns: 20, rows: 5)
+        let tui = TUI(terminal: terminal, renderScheduler: { $0() })
+        let component = DummyComponent(lines: ["hello", "world"])
+        tui.addChild(component)
+        try tui.start()
+
+        terminal.resize(columns: 20, rows: 8)
+
+        let last = terminal.outputLog.last ?? ""
+        #expect(last.contains("\u{001B}[?2026h"))
+        #expect(last.contains("\u{001B}[3J\u{001B}[2J\u{001B}[H"))
+        #expect(last.contains("hello\r\nworld"))
+    }
+
+    @MainActor @Test
     func `partial diff writes only changed lines`() throws {
         let terminal = VirtualTerminal(columns: 20, rows: 5)
         let tui = TUI(terminal: terminal, renderScheduler: { $0() })

--- a/docs/pitui-sync.md
+++ b/docs/pitui-sync.md
@@ -11,6 +11,7 @@ Context: the current upstream checkout lives at `../oss/pi-mono` (`/Users/steipe
 - `setText` and marker edits discard stale hidden paste payloads; submit expansion inserts `$` and backslashes literally instead of treating them as regular-expression replacement syntax.
 - Open autocomplete results re-query after cursor movement and destructive edits so accepting a suggestion cannot apply a result for an old cursor position.
 - ProcessTerminal now treats descriptor input as a byte stream, retaining split UTF-8 scalars, CSI/Kitty sequences, and bracketed-paste delimiters between reads.
+- The main-screen renderer now redraws on height-only terminal resizes so its viewport model stays aligned.
 - Background styles now reapply only after internal resets and always terminate with their configured reset sequence.
 - ANSI-aware wrapping normalizes CRLF and CR line endings before layout.
 


### PR DESCRIPTION
## Summary

- track terminal height alongside width in the main-screen renderer
- force a cleared full redraw after height-only resizes so viewport state stays aligned
- centralize render-state recording across full, partial, and empty frames
- document the pi-tui parity fix and add a regression test

## Proof

- `swift test` (174 tests passed)
- `swift test --sanitize=thread` (174 tests passed)
- `swift test --sanitize=address` (174 tests passed)
- `swift build -c release`
- `swiftlint --config .swiftlint.yml`
- `swiftformat --lint . --config .swiftformat`
- autoreview clean with no accepted/actionable findings
