### PR TITLE
fix: clear removed trailing terminal rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Input scrolling now uses terminal columns so CJK, fullwidth, and emoji text cannot overflow the viewport.
 - ProcessTerminal shutdown is now idempotent and no longer writes terminal-mode resets when the terminal was never started.
 - TUI sessions no longer render after shutdown, reuse stale render state after restart, or leave old rows visible when content becomes empty.
+- Partial TUI updates now clear removed trailing rows, including empty spacer rows, without leaving stale terminal content behind.
 - Height-only terminal resizes now trigger a full redraw so the main-screen viewport stays aligned.
 
 ## [0.2.1] - 2026-07-15

--- a/Sources/TauTUI/Core/TUI.swift
+++ b/Sources/TauTUI/Core/TUI.swift
@@ -146,18 +146,18 @@ public final class TUI: Container {
             return
         }
 
-        guard let diffRange = computeDiffRange(old: previousLines, new: newLines) else {
+        guard let firstChangedLine = self.firstChangedLine(old: self.previousLines, new: newLines) else {
             return // no changes
         }
 
         let viewportTop = self.cursorRow - height + 1
-        if diffRange.lowerBound < viewportTop {
+        if firstChangedLine < viewportTop {
             self.writeFullRender(newLines, clear: true)
             self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
 
-        self.writePartialRender(lines: newLines, from: diffRange.lowerBound)
+        self.writePartialRender(lines: newLines, from: firstChangedLine)
         self.recordRenderState(lines: newLines, width: width, height: height)
     }
 
@@ -168,24 +168,11 @@ public final class TUI: Container {
         self.cursorRow = max(0, lines.count - 1)
     }
 
-    private func computeDiffRange(old: [String], new: [String]) -> Range<Int>? {
-        let maxCount = max(old.count, new.count)
-        var firstChanged: Int?
-        var lastChanged: Int?
-
-        for index in 0..<maxCount {
-            let oldLine = index < old.count ? old[index] : ""
-            let newLine = index < new.count ? new[index] : ""
-            if oldLine != newLine {
-                if firstChanged == nil { firstChanged = index }
-                lastChanged = index
-            }
+    private func firstChangedLine(old: [String], new: [String]) -> Int? {
+        for index in 0..<min(old.count, new.count) where old[index] != new[index] {
+            return index
         }
-
-        guard let start = firstChanged, let end = lastChanged else {
-            return nil
-        }
-        return start..<(end + 1)
+        return old.count == new.count ? nil : min(old.count, new.count)
     }
 
     private func writeFullRender(_ lines: [String], clear: Bool = false) {
@@ -221,7 +208,10 @@ public final class TUI: Container {
 
         if self.previousLines.count > lines.count {
             let extraLines = self.previousLines.count - lines.count
-            for _ in 0..<extraLines {
+            if start == lines.count {
+                buffer += ANSI.clearLine
+            }
+            for _ in (start == lines.count ? 1 : 0)..<extraLines {
                 buffer += "\r\n" + ANSI.clearLine
             }
             buffer += ANSI.cursorUp(extraLines)

--- a/Tests/TauTUITests/TUITests.swift
+++ b/Tests/TauTUITests/TUITests.swift
@@ -99,8 +99,26 @@ struct TUIRenderingTests {
         tui.requestRender()
 
         let last = terminal.outputLog.last ?? ""
-        #expect(last.contains("\u{001B}[2K"))
-        #expect(last.contains("\u{001B}[2A"))
+        let expectedClear = ANSI.carriageReturn + ANSI.clearLine + "\r\n" + ANSI.clearLine + ANSI.cursorUp(2)
+        #expect(last.contains(expectedClear))
+    }
+
+    @MainActor @Test
+    func `partial diff clears a removed trailing empty line`() throws {
+        let terminal = VirtualTerminal(columns: 20, rows: 5)
+        let tui = TUI(terminal: terminal, renderScheduler: { $0() })
+        let component = DummyComponent(lines: ["one", ""])
+        tui.addChild(component)
+        try tui.start()
+        let writesBeforeRemoval = terminal.outputLog.count
+
+        component.lines = ["one"]
+        tui.requestRender()
+
+        #expect(terminal.outputLog.count == writesBeforeRemoval + 1)
+        let last = terminal.outputLog.last ?? ""
+        let expectedClear = ANSI.carriageReturn + ANSI.clearLine + ANSI.cursorUp(1)
+        #expect(last.contains(expectedClear))
     }
 
     @MainActor @Test


### PR DESCRIPTION
## Summary

- clear terminal rows removed by a partial render, including trailing empty spacer rows
- centralize first-change detection and avoid scanning unchanged suffixes twice
- add regressions for multi-row and empty-row removal
- document the user-visible fix in the changelog

## Proof

- `swift test --filter TUIRenderingTests` (23 passed)
- full `swift test` (174 internal + 1 external passed)
- `swiftlint lint --strict`
- `swiftformat --lint .`
- source-blind behavior validation (6/6 passed)
- structured autoreview: no actionable findings

