### PR TITLE
refactor: centralize word navigation semantics

### DIFF
--- a/Sources/TauTUI/Components/Editor.swift
+++ b/Sources/TauTUI/Components/Editor.swift
@@ -372,17 +372,12 @@ public final class Editor: Component {
         self.buffer = self.withMutatingBuffer { buf in buf.moveByWord(direction, isBoundary: self.isBoundary) }
     }
 
-    private func isPunctuation(_ ch: Character) -> Bool {
-        let punctuation: Set<Character> = Set("(){}[]<>.,;:'\"!?+-=*/\\|&%^$#@~`")
-        return punctuation.contains(ch)
-    }
-
     private func isWordCharacter(_ ch: Character) -> Bool {
-        ch.isLetter || ch.isNumber || ch == "_"
+        WordNavigation.isWordCharacter(ch)
     }
 
     private func isBoundary(_ ch: Character) -> Bool {
-        ch.isWhitespace || self.isPunctuation(ch)
+        WordNavigation.isBoundary(ch)
     }
 
     private func handlePaste(_ text: String) {

--- a/Sources/TauTUI/Components/EditorBuffer.swift
+++ b/Sources/TauTUI/Components/EditorBuffer.swift
@@ -160,9 +160,8 @@ public struct EditorBuffer: Sendable {
         }
 
         let currentLine = self.lines[self.cursorLine]
-        let chars = Array(currentLine)
 
-        if direction > 0, self.cursorCol >= chars.count {
+        if direction > 0, self.cursorCol >= currentLine.count {
             if self.cursorLine < self.lines.count - 1 {
                 self.cursorLine += 1
                 self.cursorCol = 0
@@ -170,47 +169,11 @@ public struct EditorBuffer: Sendable {
             return
         }
 
-        var idx = self.cursorCol
-        if direction > 0 {
-            while idx < chars.count, chars[idx].isWhitespace {
-                idx += 1
-            }
-
-            if idx < chars.count {
-                let isPunctuation = isBoundary(chars[idx]) && !chars[idx].isWhitespace
-                if isPunctuation {
-                    while idx < chars.count, isBoundary(chars[idx]), !chars[idx].isWhitespace {
-                        idx += 1
-                    }
-                } else {
-                    while idx < chars.count, !chars[idx].isWhitespace,
-                          !(isBoundary(chars[idx]) && !chars[idx].isWhitespace)
-                    {
-                        idx += 1
-                    }
-                }
-            }
-        } else {
-            while idx > 0, chars[idx - 1].isWhitespace {
-                idx -= 1
-            }
-
-            if idx > 0 {
-                let isPunctuation = isBoundary(chars[idx - 1]) && !chars[idx - 1].isWhitespace
-                if isPunctuation {
-                    while idx > 0, isBoundary(chars[idx - 1]), !chars[idx - 1].isWhitespace {
-                        idx -= 1
-                    }
-                } else {
-                    while idx > 0, !chars[idx - 1].isWhitespace,
-                          !(isBoundary(chars[idx - 1]) && !chars[idx - 1].isWhitespace)
-                    {
-                        idx -= 1
-                    }
-                }
-            }
-        }
-
-        self.cursorCol = max(0, min(chars.count, idx))
+        let navigationDirection: WordNavigationDirection = direction > 0 ? .forward : .backward
+        self.cursorCol = WordNavigation.destination(
+            in: currentLine,
+            from: self.cursorCol,
+            direction: navigationDirection,
+            isBoundary: isBoundary)
     }
 }

--- a/Sources/TauTUI/Components/Input.swift
+++ b/Sources/TauTUI/Components/Input.swift
@@ -147,55 +147,12 @@ public final class Input: Component {
 
     private func moveWordBackwards() {
         guard self.cursor > 0 else { return }
-        let chars = Array(self.value)
-        var idx = self.cursor
-
-        while idx > 0, chars[idx - 1].isWhitespace {
-            idx -= 1
-        }
-
-        if idx > 0 {
-            if self.isPunctuation(chars[idx - 1]) {
-                while idx > 0, self.isPunctuation(chars[idx - 1]) {
-                    idx -= 1
-                }
-            } else {
-                while idx > 0, !chars[idx - 1].isWhitespace, !self.isPunctuation(chars[idx - 1]) {
-                    idx -= 1
-                }
-            }
-        }
-
-        self.cursor = idx
+        self.cursor = WordNavigation.destination(in: self.value, from: self.cursor, direction: .backward)
     }
 
     private func moveWordForwards() {
-        let chars = Array(self.value)
-        guard self.cursor < chars.count else { return }
-        var idx = self.cursor
-
-        while idx < chars.count, chars[idx].isWhitespace {
-            idx += 1
-        }
-
-        if idx < chars.count {
-            if self.isPunctuation(chars[idx]) {
-                while idx < chars.count, self.isPunctuation(chars[idx]) {
-                    idx += 1
-                }
-            } else {
-                while idx < chars.count, !chars[idx].isWhitespace, !self.isPunctuation(chars[idx]) {
-                    idx += 1
-                }
-            }
-        }
-
-        self.cursor = idx
-    }
-
-    private func isPunctuation(_ ch: Character) -> Bool {
-        let punctuation: Set<Character> = Set("(){}[]<>.,;:'\"!?+-=*/\\|&%^$#@~`")
-        return punctuation.contains(ch)
+        guard self.cursor < self.value.count else { return }
+        self.cursor = WordNavigation.destination(in: self.value, from: self.cursor, direction: .forward)
     }
 
     private func insert(_ string: String) {

--- a/Sources/TauTUI/Utilities/WordNavigation.swift
+++ b/Sources/TauTUI/Utilities/WordNavigation.swift
@@ -1,0 +1,79 @@
+enum WordNavigationDirection {
+    case backward
+    case forward
+}
+
+/// Shared readline-style word classification and cursor movement.
+enum WordNavigation {
+    private static let punctuation: Set<Character> = Set("(){}[]<>.,;:'\"!?+-=*/\\|&%^$#@~`")
+
+    static func isWordCharacter(_ character: Character) -> Bool {
+        character.isLetter || character.isNumber || character == "_"
+    }
+
+    static func isBoundary(_ character: Character) -> Bool {
+        character.isWhitespace || self.punctuation.contains(character)
+    }
+
+    static func destination(
+        in text: String,
+        from cursor: Int,
+        direction: WordNavigationDirection,
+        isBoundary: (Character) -> Bool = WordNavigation.isBoundary) -> Int
+    {
+        let characters = Array(text)
+        var index = min(max(cursor, 0), characters.count)
+
+        switch direction {
+        case .forward:
+            while index < characters.count, characters[index].isWhitespace {
+                index += 1
+            }
+
+            if index < characters.count {
+                let isPunctuation = isBoundary(characters[index]) && !characters[index].isWhitespace
+                if isPunctuation {
+                    while index < characters.count,
+                          isBoundary(characters[index]),
+                          !characters[index].isWhitespace
+                    {
+                        index += 1
+                    }
+                } else {
+                    while index < characters.count,
+                          !characters[index].isWhitespace,
+                          !isBoundary(characters[index])
+                    {
+                        index += 1
+                    }
+                }
+            }
+
+        case .backward:
+            while index > 0, characters[index - 1].isWhitespace {
+                index -= 1
+            }
+
+            if index > 0 {
+                let isPunctuation = isBoundary(characters[index - 1]) && !characters[index - 1].isWhitespace
+                if isPunctuation {
+                    while index > 0,
+                          isBoundary(characters[index - 1]),
+                          !characters[index - 1].isWhitespace
+                    {
+                        index -= 1
+                    }
+                } else {
+                    while index > 0,
+                          !characters[index - 1].isWhitespace,
+                          !isBoundary(characters[index - 1])
+                    {
+                        index -= 1
+                    }
+                }
+            }
+        }
+
+        return index
+    }
+}

--- a/Tests/TauTUITests/WordNavigationParityTests.swift
+++ b/Tests/TauTUITests/WordNavigationParityTests.swift
@@ -1,0 +1,72 @@
+import Testing
+@testable import TauTUI
+
+@Suite("Word navigation parity")
+struct WordNavigationParityTests {
+    struct Fixture: Sendable {
+        let text: String
+        let backwardInsertion: String
+        let forwardInsertion: String
+        let backwardDeletion: String
+    }
+
+    static let fixtures = [
+        Fixture(
+            text: "foo bar... baz",
+            backwardInsertion: "foo bar... |baz",
+            forwardInsertion: "foo| bar... baz",
+            backwardDeletion: "foo bar... "),
+        Fixture(
+            text: "   foo bar",
+            backwardInsertion: "   foo |bar",
+            forwardInsertion: "   foo| bar",
+            backwardDeletion: "   foo "),
+        Fixture(
+            text: "foo 😀😀 bar",
+            backwardInsertion: "foo 😀😀 |bar",
+            forwardInsertion: "foo| 😀😀 bar",
+            backwardDeletion: "foo 😀😀 "),
+    ]
+
+    @Test(arguments: fixtures)
+    func `Input and Editor share word movement`(_ fixture: Fixture) {
+        let inputBackward = Input(value: fixture.text)
+        inputBackward.handle(input: .key(.arrowLeft, modifiers: [.control]))
+        inputBackward.handle(input: .key(.character("|")))
+
+        let editorBackward = Editor()
+        editorBackward.setText(fixture.text)
+        editorBackward.handle(input: .key(.arrowLeft, modifiers: [.control]))
+        editorBackward.handle(input: .key(.character("|")))
+
+        #expect(inputBackward.value == fixture.backwardInsertion)
+        #expect(editorBackward.getText() == fixture.backwardInsertion)
+
+        let inputForward = Input(value: fixture.text)
+        inputForward.handle(input: .key(.home))
+        inputForward.handle(input: .key(.arrowRight, modifiers: [.control]))
+        inputForward.handle(input: .key(.character("|")))
+
+        let editorForward = Editor()
+        editorForward.setText(fixture.text)
+        editorForward.handle(input: .key(.home))
+        editorForward.handle(input: .key(.arrowRight, modifiers: [.control]))
+        editorForward.handle(input: .key(.character("|")))
+
+        #expect(inputForward.value == fixture.forwardInsertion)
+        #expect(editorForward.getText() == fixture.forwardInsertion)
+    }
+
+    @Test(arguments: fixtures)
+    func `Input and Editor share backward deletion`(_ fixture: Fixture) {
+        let input = Input(value: fixture.text)
+        input.handle(input: .key(.character("w"), modifiers: [.control]))
+
+        let editor = Editor()
+        editor.setText(fixture.text)
+        editor.handle(input: .key(.character("w"), modifiers: [.control]))
+
+        #expect(input.value == fixture.backwardDeletion)
+        #expect(editor.getText() == fixture.backwardDeletion)
+    }
+}


### PR DESCRIPTION
## Summary

- give `Input`, `EditorBuffer`, and `Editor` one internal owner for readline-style word classification and cursor movement
- remove the duplicated movement loops without changing public API
- add shared whitespace, punctuation, and Unicode parity fixtures covering movement and backward deletion

## Proof

- `swift test --parallel` (176 TauTUI tests plus 1 external test)
- `swift build --configuration debug`
- SwiftLint: 0 violations across 64 files
- SwiftFormat lint: 0 violations across 65 files
- P0-P2 autoreview: clean, correctness 0.99
