### PR TITLE
fix: preserve split terminal escape sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 - Editor and Input now share one Unicode-preserving paste sanitizer that strips terminal control characters and normalizes tabs and line endings.
 - Open autocomplete suggestions now refresh after cursor movement and text deletion instead of applying results computed for a stale cursor position.
 - ProcessTerminal now preserves split UTF-8 scalars, CSI/Kitty key sequences, and bracketed-paste delimiters across arbitrary descriptor read boundaries without letting malformed UTF-8 prefixes stall subsequent input.
-- ProcessTerminal now resolves local Escape presses promptly while giving SSH-split Option chords and incomplete control sequences separate reassembly windows, without letting stale cancelled timers corrupt newer input.
+- ProcessTerminal now preserves the local Escape/Option ambiguity window while giving SSH-split Option chords and incomplete control sequences separate reassembly windows, without letting stale cancelled timers corrupt newer input.
 - Background styles now always finish with a reset instead of leaking their color into later terminal output.
 - ANSI-aware wrapping now treats CRLF and CR as line endings, preserving line boundaries from cross-platform terminal output.
 - ChatDemo no longer retains its view model through the editor submit callback and builds without Swift 6.4 capture warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Editor and Input now share one Unicode-preserving paste sanitizer that strips terminal control characters and normalizes tabs and line endings.
 - Open autocomplete suggestions now refresh after cursor movement and text deletion instead of applying results computed for a stale cursor position.
 - ProcessTerminal now preserves split UTF-8 scalars, CSI/Kitty key sequences, and bracketed-paste delimiters across arbitrary descriptor read boundaries without letting malformed UTF-8 prefixes stall subsequent input.
+- ProcessTerminal now resolves local Escape presses promptly while giving SSH-split Option chords and incomplete control sequences separate reassembly windows, without letting stale cancelled timers corrupt newer input.
 - Background styles now always finish with a reset instead of leaking their color into later terminal output.
 - ANSI-aware wrapping now treats CRLF and CR as line endings, preserving line boundaries from cross-platform terminal output.
 - ChatDemo no longer retains its view model through the editor submit callback and builds without Swift 6.4 capture warnings.

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ public protocol Terminal: AnyObject {
 }
 ```
 
-- `ProcessTerminal` puts stdin in raw mode, enables Kitty keyboard protocol, normalizes modifier encodings (CSI params, ESC-prefix meta), turns bracketed paste on/off, and emits `TerminalInput` events (`.key`, `.paste`). Raw bytes are opt-in via `emitsRawInputEvents` (used by `KeyTester`).
+- `ProcessTerminal` puts stdin in raw mode, enables Kitty keyboard protocol, normalizes modifier encodings (CSI params, ESC-prefix meta), gives split Option chords a longer reassembly window over SSH, turns bracketed paste on/off, and emits `TerminalInput` events (`.key`, `.paste`). Raw bytes are opt-in via `emitsRawInputEvents` (used by `KeyTester`).
 - `VirtualTerminal` records writes for tests, tracks viewport/scrollback, and exposes helper methods (`flush()`, `getViewport()`, `getScrollBuffer()`, `getCursorPosition()`).
 
 ## Examples

--- a/Sources/TauTUI/Terminal/Terminal.swift
+++ b/Sources/TauTUI/Terminal/Terminal.swift
@@ -93,7 +93,7 @@ public final class ProcessTerminal: Terminal {
     private var escapeFlushWorkItem: DispatchWorkItem?
     private var escapeFlushGeneration: UInt = 0
 
-    private let loneEscapeTimeoutMilliseconds: Int
+    private let escapeAmbiguityTimeoutMilliseconds: Int
     private let escapeFlushScheduler: (Int, DispatchWorkItem) -> Void
 
     /// Emit `.raw` events for debugging/inspection (e.g. KeyTester).
@@ -113,8 +113,8 @@ public final class ProcessTerminal: Terminal {
     private static let optionEnterCSI = "\u{001B}[13;3~"
     private static let optionEnterMeta = "\u{001B}\r"
 
-    private static let defaultLoneEscapeTimeoutMilliseconds = 10
-    private static let sshLoneEscapeTimeoutMilliseconds = 100
+    private static let localEscapeAmbiguityTimeoutMilliseconds = 30
+    private static let sshEscapeAmbiguityTimeoutMilliseconds = 100
     private static let incompleteEscapeSequenceTimeoutMilliseconds = 50
 
     public convenience init() {
@@ -135,13 +135,16 @@ public final class ProcessTerminal: Terminal {
     {
         self.inputFD = FileDescriptor(rawValue: inputFileDescriptor)
         self.outputFD = FileDescriptor(rawValue: outputFileDescriptor)
-        self.loneEscapeTimeoutMilliseconds = Self.resolveLoneEscapeTimeoutMilliseconds(environment: environment)
+        self.escapeAmbiguityTimeoutMilliseconds = Self.resolveEscapeAmbiguityTimeoutMilliseconds(
+            environment: environment)
         self.escapeFlushScheduler = escapeFlushScheduler
     }
 
-    static func resolveLoneEscapeTimeoutMilliseconds(environment: [String: String]) -> Int {
+    static func resolveEscapeAmbiguityTimeoutMilliseconds(environment: [String: String]) -> Int {
         let isSSH = environment["SSH_CONNECTION"]?.isEmpty == false || environment["SSH_TTY"]?.isEmpty == false
-        return isSSH ? Self.sshLoneEscapeTimeoutMilliseconds : Self.defaultLoneEscapeTimeoutMilliseconds
+        return isSSH
+            ? Self.sshEscapeAmbiguityTimeoutMilliseconds
+            : Self.localEscapeAmbiguityTimeoutMilliseconds
     }
 
     /// Testing helper: parse a raw input string into `TerminalInput` events
@@ -449,7 +452,7 @@ public final class ProcessTerminal: Terminal {
         self.escapeFlushGeneration &+= 1
         let generation = self.escapeFlushGeneration
         let timeout = self.pendingInput == "\u{001B}"
-            ? self.loneEscapeTimeoutMilliseconds
+            ? self.escapeAmbiguityTimeoutMilliseconds
             : Self.incompleteEscapeSequenceTimeoutMilliseconds
         let workItem = DispatchWorkItem { [weak self] in
             guard let self, self.escapeFlushGeneration == generation else { return }

--- a/Sources/TauTUI/Terminal/Terminal.swift
+++ b/Sources/TauTUI/Terminal/Terminal.swift
@@ -94,7 +94,7 @@ public final class ProcessTerminal: Terminal {
     private var escapeFlushGeneration: UInt = 0
 
     private let escapeAmbiguityTimeoutMilliseconds: Int
-    private let escapeFlushScheduler: (Int, DispatchWorkItem) -> Void
+    private let escapeFlushScheduler: (Int, @escaping () -> Void) -> DispatchWorkItem
 
     /// Emit `.raw` events for debugging/inspection (e.g. KeyTester).
     /// Off by default because `.key`/`.paste` already cover functional input.
@@ -127,10 +127,12 @@ public final class ProcessTerminal: Terminal {
         inputFileDescriptor: Int32,
         outputFileDescriptor: Int32,
         environment: [String: String] = ProcessInfo.processInfo.environment,
-        escapeFlushScheduler: @escaping (Int, DispatchWorkItem) -> Void = { milliseconds, workItem in
+        escapeFlushScheduler: @escaping (Int, @escaping () -> Void) -> DispatchWorkItem = { milliseconds, action in
+            let workItem = DispatchWorkItem(block: action)
             DispatchQueue.main.asyncAfter(
                 deadline: .now() + .milliseconds(milliseconds),
                 execute: workItem)
+            return workItem
         })
     {
         self.inputFD = FileDescriptor(rawValue: inputFileDescriptor)
@@ -454,7 +456,7 @@ public final class ProcessTerminal: Terminal {
         let timeout = self.pendingInput == "\u{001B}"
             ? self.escapeAmbiguityTimeoutMilliseconds
             : Self.incompleteEscapeSequenceTimeoutMilliseconds
-        let workItem = DispatchWorkItem { [weak self] in
+        let workItem = self.escapeFlushScheduler(timeout) { [weak self] in
             guard let self, self.escapeFlushGeneration == generation else { return }
             self.escapeFlushWorkItem = nil
             guard self.pendingInput.first == "\u{001B}" else { return }
@@ -463,7 +465,6 @@ public final class ProcessTerminal: Terminal {
             self.processPendingInput()
         }
         self.escapeFlushWorkItem = workItem
-        self.escapeFlushScheduler(timeout, workItem)
     }
 
     private func cancelEscapeFlush() {

--- a/Sources/TauTUI/Terminal/Terminal.swift
+++ b/Sources/TauTUI/Terminal/Terminal.swift
@@ -91,6 +91,10 @@ public final class ProcessTerminal: Terminal {
     private var isInBracketedPaste = false
     private var pasteBuffer = ""
     private var escapeFlushWorkItem: DispatchWorkItem?
+    private var escapeFlushGeneration: UInt = 0
+
+    private let loneEscapeTimeoutMilliseconds: Int
+    private let escapeFlushScheduler: (Int, DispatchWorkItem) -> Void
 
     /// Emit `.raw` events for debugging/inspection (e.g. KeyTester).
     /// Off by default because `.key`/`.paste` already cover functional input.
@@ -109,15 +113,35 @@ public final class ProcessTerminal: Terminal {
     private static let optionEnterCSI = "\u{001B}[13;3~"
     private static let optionEnterMeta = "\u{001B}\r"
 
+    private static let defaultLoneEscapeTimeoutMilliseconds = 10
+    private static let sshLoneEscapeTimeoutMilliseconds = 100
+    private static let incompleteEscapeSequenceTimeoutMilliseconds = 50
+
     public convenience init() {
         self.init(
             inputFileDescriptor: FileDescriptor.standardInput.rawValue,
             outputFileDescriptor: FileDescriptor.standardOutput.rawValue)
     }
 
-    init(inputFileDescriptor: Int32, outputFileDescriptor: Int32) {
+    init(
+        inputFileDescriptor: Int32,
+        outputFileDescriptor: Int32,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        escapeFlushScheduler: @escaping (Int, DispatchWorkItem) -> Void = { milliseconds, workItem in
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + .milliseconds(milliseconds),
+                execute: workItem)
+        })
+    {
         self.inputFD = FileDescriptor(rawValue: inputFileDescriptor)
         self.outputFD = FileDescriptor(rawValue: outputFileDescriptor)
+        self.loneEscapeTimeoutMilliseconds = Self.resolveLoneEscapeTimeoutMilliseconds(environment: environment)
+        self.escapeFlushScheduler = escapeFlushScheduler
+    }
+
+    static func resolveLoneEscapeTimeoutMilliseconds(environment: [String: String]) -> Int {
+        let isSSH = environment["SSH_CONNECTION"]?.isEmpty == false || environment["SSH_TTY"]?.isEmpty == false
+        return isSSH ? Self.sshLoneEscapeTimeoutMilliseconds : Self.defaultLoneEscapeTimeoutMilliseconds
     }
 
     /// Testing helper: parse a raw input string into `TerminalInput` events
@@ -198,8 +222,7 @@ public final class ProcessTerminal: Terminal {
 
         self.inputHandler = nil
         self.resizeHandler = nil
-        self.escapeFlushWorkItem?.cancel()
-        self.escapeFlushWorkItem = nil
+        self.cancelEscapeFlush()
         self.pendingUTF8Bytes.removeAll(keepingCapacity: false)
         self.pendingInput.removeAll(keepingCapacity: false)
         self.pasteBuffer.removeAll(keepingCapacity: false)
@@ -328,8 +351,7 @@ public final class ProcessTerminal: Terminal {
 
     fileprivate func handleRawChunk(_ chunk: String) {
         guard !chunk.isEmpty else { return }
-        self.escapeFlushWorkItem?.cancel()
-        self.escapeFlushWorkItem = nil
+        self.cancelEscapeFlush()
         if self.emitsRawInputEvents {
             self.inputHandler?(.raw(chunk))
         }
@@ -424,8 +446,13 @@ public final class ProcessTerminal: Terminal {
 
     private func scheduleIncompleteEscapeFlush() {
         guard self.escapeFlushWorkItem == nil else { return }
+        self.escapeFlushGeneration &+= 1
+        let generation = self.escapeFlushGeneration
+        let timeout = self.pendingInput == "\u{001B}"
+            ? self.loneEscapeTimeoutMilliseconds
+            : Self.incompleteEscapeSequenceTimeoutMilliseconds
         let workItem = DispatchWorkItem { [weak self] in
-            guard let self else { return }
+            guard let self, self.escapeFlushGeneration == generation else { return }
             self.escapeFlushWorkItem = nil
             guard self.pendingInput.first == "\u{001B}" else { return }
             let escape = self.pendingInput.removeFirst()
@@ -433,7 +460,13 @@ public final class ProcessTerminal: Terminal {
             self.processPendingInput()
         }
         self.escapeFlushWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(30), execute: workItem)
+        self.escapeFlushScheduler(timeout, workItem)
+    }
+
+    private func cancelEscapeFlush() {
+        self.escapeFlushWorkItem?.cancel()
+        self.escapeFlushWorkItem = nil
+        self.escapeFlushGeneration &+= 1
     }
 
     private func handleCharacter(_ char: Character) {

--- a/Tests/TauTUITests/TerminalInputBufferTests.swift
+++ b/Tests/TauTUITests/TerminalInputBufferTests.swift
@@ -5,7 +5,7 @@ import Testing
 private final class ManualEscapeFlushScheduler {
     private struct ScheduledWork {
         let deadline: Int
-        let workItem: DispatchWorkItem
+        let action: () -> Void
     }
 
     private var now = 0
@@ -13,16 +13,19 @@ private final class ManualEscapeFlushScheduler {
 
     var delays: [Int] = []
 
-    func schedule(milliseconds: Int, workItem: DispatchWorkItem) {
+    func schedule(milliseconds: Int, action: @escaping () -> Void) -> DispatchWorkItem {
         self.delays.append(milliseconds)
-        self.scheduled.append(ScheduledWork(deadline: self.now + milliseconds, workItem: workItem))
+        self.scheduled.append(ScheduledWork(deadline: self.now + milliseconds, action: action))
+        return DispatchWorkItem {}
     }
 
     func advance(milliseconds: Int) {
         self.now += milliseconds
         let due = self.scheduled.filter { $0.deadline <= self.now }
         self.scheduled.removeAll { $0.deadline <= self.now }
-        due.forEach { $0.workItem.perform() }
+        // Run the callback independently of its cancelled production handle to model
+        // work that already began while cancellation raced with the dispatch queue.
+        due.forEach { $0.action() }
     }
 }
 
@@ -101,9 +104,9 @@ struct TerminalInputBufferTests {
         scheduler.advance(milliseconds: 5)
         #expect(parser.parseForTests("[").isEmpty)
 
-        // Dispatch cancellation does not guarantee that an already-enqueued work item
-        // cannot begin. Exercise the stale item explicitly before the CSI completes.
-        scheduler.advance(milliseconds: 5)
+        // Advance through the original local timer's 30 ms deadline. The test scheduler
+        // executes its callback despite cancellation to model an already-started item.
+        scheduler.advance(milliseconds: 25)
         let events = parser.parseForTests("1;3D")
 
         #expect(events.count == 1)

--- a/Tests/TauTUITests/TerminalInputBufferTests.swift
+++ b/Tests/TauTUITests/TerminalInputBufferTests.swift
@@ -29,11 +29,31 @@ private final class ManualEscapeFlushScheduler {
 @Suite("Terminal input buffering")
 struct TerminalInputBufferTests {
     @Test
-    func `lone escape timeout is prompt locally and tolerant over SSH`() {
-        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: [:]) == 10)
-        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: ["SSH_TTY": "/dev/pts/1"]) == 100)
-        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: ["SSH_CONNECTION": "host"]) == 100)
-        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: ["SSH_TTY": ""]) == 10)
+    func `escape ambiguity timeout preserves local and SSH compatibility`() {
+        #expect(ProcessTerminal.resolveEscapeAmbiguityTimeoutMilliseconds(environment: [:]) == 30)
+        #expect(ProcessTerminal
+            .resolveEscapeAmbiguityTimeoutMilliseconds(environment: ["SSH_TTY": "/dev/pts/1"]) == 100)
+        #expect(ProcessTerminal
+            .resolveEscapeAmbiguityTimeoutMilliseconds(environment: ["SSH_CONNECTION": "host"]) == 100)
+        #expect(ProcessTerminal.resolveEscapeAmbiguityTimeoutMilliseconds(environment: ["SSH_TTY": ""]) == 30)
+    }
+
+    @Test
+    func `local split option enter remains one modified key through prior ambiguity window`() {
+        let scheduler = ManualEscapeFlushScheduler()
+        let parser = self.makeParser(environment: [:], scheduler: scheduler)
+
+        #expect(parser.parseForTests("\u{001B}").isEmpty)
+        #expect(scheduler.delays == [30])
+        scheduler.advance(milliseconds: 20)
+
+        let events = parser.parseForTests("\r")
+        #expect(events.count == 1)
+        guard events.count == 1, case let .key(.enter, modifiers) = events[0] else {
+            Issue.record("expected one local Option-Enter event")
+            return
+        }
+        #expect(modifiers == [.option])
     }
 
     @Test

--- a/Tests/TauTUITests/TerminalInputBufferTests.swift
+++ b/Tests/TauTUITests/TerminalInputBufferTests.swift
@@ -1,0 +1,107 @@
+import Dispatch
+import Testing
+@testable import TauTUI
+
+private final class ManualEscapeFlushScheduler {
+    private struct ScheduledWork {
+        let deadline: Int
+        let workItem: DispatchWorkItem
+    }
+
+    private var now = 0
+    private var scheduled: [ScheduledWork] = []
+
+    var delays: [Int] = []
+
+    func schedule(milliseconds: Int, workItem: DispatchWorkItem) {
+        self.delays.append(milliseconds)
+        self.scheduled.append(ScheduledWork(deadline: self.now + milliseconds, workItem: workItem))
+    }
+
+    func advance(milliseconds: Int) {
+        self.now += milliseconds
+        let due = self.scheduled.filter { $0.deadline <= self.now }
+        self.scheduled.removeAll { $0.deadline <= self.now }
+        due.forEach { $0.workItem.perform() }
+    }
+}
+
+@Suite("Terminal input buffering")
+struct TerminalInputBufferTests {
+    @Test
+    func `lone escape timeout is prompt locally and tolerant over SSH`() {
+        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: [:]) == 10)
+        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: ["SSH_TTY": "/dev/pts/1"]) == 100)
+        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: ["SSH_CONNECTION": "host"]) == 100)
+        #expect(ProcessTerminal.resolveLoneEscapeTimeoutMilliseconds(environment: ["SSH_TTY": ""]) == 10)
+    }
+
+    @Test
+    func `SSH split option enter remains one modified key`() {
+        let scheduler = ManualEscapeFlushScheduler()
+        let parser = self.makeParser(environment: ["SSH_TTY": "/dev/pts/1"], scheduler: scheduler)
+
+        #expect(parser.parseForTests("\u{001B}").isEmpty)
+        #expect(scheduler.delays == [100])
+        scheduler.advance(milliseconds: 50)
+
+        let events = parser.parseForTests("\r")
+        #expect(events.count == 1)
+        guard events.count == 1, case let .key(.enter, modifiers) = events[0] else {
+            Issue.record("expected one Option-Enter event")
+            return
+        }
+        #expect(modifiers == [.option])
+    }
+
+    @Test
+    func `incomplete CSI uses its own sequence timeout over SSH`() {
+        let scheduler = ManualEscapeFlushScheduler()
+        let parser = self.makeParser(environment: ["SSH_TTY": "/dev/pts/1"], scheduler: scheduler)
+
+        #expect(parser.parseForTests("\u{001B}[1;").isEmpty)
+        #expect(scheduler.delays == [50])
+        scheduler.advance(milliseconds: 49)
+
+        let events = parser.parseForTests("3D")
+        #expect(events.count == 1)
+        guard events.count == 1, case let .key(.arrowLeft, modifiers) = events[0] else {
+            Issue.record("expected one Option-Left event")
+            return
+        }
+        #expect(modifiers == [.option])
+    }
+
+    @Test
+    func `cancelled lone escape timer cannot flush a newer sequence`() {
+        let scheduler = ManualEscapeFlushScheduler()
+        let parser = self.makeParser(environment: [:], scheduler: scheduler)
+
+        #expect(parser.parseForTests("\u{001B}").isEmpty)
+        scheduler.advance(milliseconds: 5)
+        #expect(parser.parseForTests("[").isEmpty)
+
+        // Dispatch cancellation does not guarantee that an already-enqueued work item
+        // cannot begin. Exercise the stale item explicitly before the CSI completes.
+        scheduler.advance(milliseconds: 5)
+        let events = parser.parseForTests("1;3D")
+
+        #expect(events.count == 1)
+        guard events.count == 1, case let .key(.arrowLeft, modifiers) = events[0] else {
+            Issue.record("expected the newer CSI sequence to remain intact")
+            return
+        }
+        #expect(modifiers == [.option])
+    }
+
+    private func makeParser(
+        environment: [String: String],
+        scheduler: ManualEscapeFlushScheduler) -> ProcessTerminal
+    {
+        ProcessTerminal(
+            inputFileDescriptor: 0,
+            outputFileDescriptor: 1,
+            environment: environment,
+            escapeFlushScheduler: scheduler.schedule)
+    }
+}

--- a/docs/pitui-sync.md
+++ b/docs/pitui-sync.md
@@ -11,7 +11,7 @@ Context: the current upstream checkout lives at `../../oss/pi-mono` (`/Users/ste
 - `setText` and marker edits discard stale hidden paste payloads; submit expansion inserts `$` and backslashes literally instead of treating them as regular-expression replacement syntax.
 - Open autocomplete results re-query after cursor movement and destructive edits so accepting a suggestion cannot apply a result for an old cursor position.
 - ProcessTerminal now treats descriptor input as a byte stream, retaining split UTF-8 scalars, CSI/Kitty sequences, and bracketed-paste delimiters between reads.
-- Lone Escape presses now use a prompt local timeout while SSH-split Option chords and incomplete escape sequences retain independent, longer reassembly windows.
+- Escape/Option ambiguity retains its 30 ms local window, while SSH-split Option chords and incomplete escape sequences use independent 100 ms and 50 ms reassembly windows.
 - The main-screen renderer now redraws on height-only terminal resizes so its viewport model stays aligned.
 - Background styles now reapply only after internal resets and always terminate with their configured reset sequence.
 - ANSI-aware wrapping normalizes CRLF and CR line endings before layout.

--- a/docs/pitui-sync.md
+++ b/docs/pitui-sync.md
@@ -1,6 +1,6 @@
-# pi-tui sync log (Aug 12, 2026)
+# pi-tui sync log (Aug 13, 2026)
 
-Context: the current upstream checkout lives at `../../oss/pi-mono` (`/Users/steipete/Projects/oss/pi-mono`) relative to this repo. Current `origin/main` inspected: `581d75a89` on **2026-08-12**; the latest released TUI entry is **0.84.1 (2026-08-07)**.
+Context: the current upstream checkout lives at `../../oss/pi-mono` (`/Users/steipete/Projects/oss/pi-mono`) relative to this repo. Current `origin/main` inspected: `9d2ec7ffa` on **2026-08-13**; the latest released TUI entry is **0.84.1 (2026-08-07)**.
 
 ## Changes synchronized in TauTUI 0.2.2
 
@@ -11,6 +11,7 @@ Context: the current upstream checkout lives at `../../oss/pi-mono` (`/Users/ste
 - `setText` and marker edits discard stale hidden paste payloads; submit expansion inserts `$` and backslashes literally instead of treating them as regular-expression replacement syntax.
 - Open autocomplete results re-query after cursor movement and destructive edits so accepting a suggestion cannot apply a result for an old cursor position.
 - ProcessTerminal now treats descriptor input as a byte stream, retaining split UTF-8 scalars, CSI/Kitty sequences, and bracketed-paste delimiters between reads.
+- Lone Escape presses now use a prompt local timeout while SSH-split Option chords and incomplete escape sequences retain independent, longer reassembly windows.
 - The main-screen renderer now redraws on height-only terminal resizes so its viewport model stays aligned.
 - Background styles now reapply only after internal resets and always terminate with their configured reset sequence.
 - ANSI-aware wrapping normalizes CRLF and CR line endings before layout.


### PR DESCRIPTION
## Summary

- preserve the established 30 ms local Escape/Option ambiguity window while allowing 100 ms for SSH-split Option chords
- keep fragmented CSI/Kitty sequences on an independent 50 ms completion window
- invalidate cancelled flush work with a generation token so an older timer cannot consume newer buffered input
- add deterministic coverage for local Option input arriving inside the former 10–30 ms regression interval

This keeps TauTUI's existing local Option/Meta compatibility while adopting independent buffering windows for incomplete terminal sequences and slower SSH delivery.

## Proof

- `swift test --filter TerminalInputBufferTests` (5 tests)
- `swift test --parallel` (182 tests across both test products)
- `swift build --configuration release`
- `swiftlint --config .swiftlint.yml` (0 violations)
- `swiftformat --lint . --config .swiftformat` (0 files)
- mutation proof: removing the generation guard makes the stale-timer regression fail with four events instead of one
- autoreview: clean, no accepted/actionable findings

## Docs

- updated the README terminal behavior, 0.2.2 changelog, and pi-tui sync reference
