### PR TITLE
fix: validate full render width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - TUI sessions no longer render after shutdown, reuse stale render state after restart, or leave old rows visible when content becomes empty.
 - Partial TUI updates now clear removed trailing rows, including empty spacer rows, without leaving stale terminal content behind.
 - Height-only terminal resizes now trigger a full redraw so the main-screen viewport stays aligned.
+- Full and partial terminal redraws now enforce the same visible-width invariant before writing component output.
 
 ## [0.2.1] - 2026-07-15
 - TruncatedText no longer emits a full three-dot ellipsis when the available width is 1 or 2, which had made the rendered line wider than the requested width; it now fills with as many dots as fit, matching the public `truncate` helper. Thanks @devYRPauli.

--- a/Sources/TauTUI/Core/TUI.swift
+++ b/Sources/TauTUI/Core/TUI.swift
@@ -9,6 +9,12 @@ import Darwin
 /// Main runtime responsible for differential rendering and input routing.
 @MainActor
 public final class TUI: Container {
+    struct RenderWidthViolation: Equatable, Sendable {
+        let lineIndex: Int
+        let visibleWidth: Int
+        let maximumWidth: Int
+    }
+
     private let terminal: Terminal
     private let scheduleRender: (@MainActor @Sendable @escaping () -> Void) -> Void
     private var focusedComponent: Component?
@@ -128,20 +134,20 @@ public final class TUI: Container {
 
         guard !newLines.isEmpty else {
             if !self.previousLines.isEmpty {
-                self.writePartialRender(lines: [""], from: 0)
+                self.writePartialRender(lines: [""], from: 0, width: width)
             }
             self.recordRenderState(lines: [], width: width, height: height)
             return
         }
 
         if self.previousLines.isEmpty {
-            self.writeFullRender(newLines)
+            self.writeFullRender(newLines, width: width)
             self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
 
         if self.previousWidth != width || self.previousHeight != height {
-            self.writeFullRender(newLines, clear: true)
+            self.writeFullRender(newLines, width: width, clear: true)
             self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
@@ -152,12 +158,12 @@ public final class TUI: Container {
 
         let viewportTop = self.cursorRow - height + 1
         if firstChangedLine < viewportTop {
-            self.writeFullRender(newLines, clear: true)
+            self.writeFullRender(newLines, width: width, clear: true)
             self.recordRenderState(lines: newLines, width: width, height: height)
             return
         }
 
-        self.writePartialRender(lines: newLines, from: firstChangedLine)
+        self.writePartialRender(lines: newLines, from: firstChangedLine, width: width)
         self.recordRenderState(lines: newLines, width: width, height: height)
     }
 
@@ -175,7 +181,8 @@ public final class TUI: Container {
         return old.count == new.count ? nil : min(old.count, new.count)
     }
 
-    private func writeFullRender(_ lines: [String], clear: Bool = false) {
+    private func writeFullRender(_ lines: [String], width: Int, clear: Bool = false) {
+        self.validateRenderedLines(lines, width: width)
         var buffer = ANSI.syncStart
         if clear {
             buffer += ANSI.clearScrollbackAndScreen
@@ -185,7 +192,8 @@ public final class TUI: Container {
         self.terminal.write(buffer)
     }
 
-    private func writePartialRender(lines: [String], from start: Int) {
+    private func writePartialRender(lines: [String], from start: Int, width: Int) {
+        self.validateRenderedLines(lines, width: width, from: start)
         var buffer = ANSI.syncStart
         let lineDiff = start - self.cursorRow
         if lineDiff > 0 {
@@ -199,9 +207,6 @@ public final class TUI: Container {
         for index in start..<lines.count {
             if index > start { buffer += "\r\n" }
             let line = lines[index]
-            if !self.containsImage(line) {
-                precondition(VisibleWidth.measure(line) <= self.terminal.columns, "Rendered line exceeds width")
-            }
             buffer += ANSI.clearLine
             buffer += line
         }
@@ -221,7 +226,32 @@ public final class TUI: Container {
         self.terminal.write(buffer)
     }
 
-    private func containsImage(_ line: String) -> Bool {
+    nonisolated static func firstRenderWidthViolation(
+        in lines: [String],
+        width: Int,
+        from start: Int = 0) -> RenderWidthViolation?
+    {
+        let lowerBound = min(max(start, 0), lines.count)
+        for index in lowerBound..<lines.count where !Self.containsImage(lines[index]) {
+            let lineWidth = VisibleWidth.measure(lines[index])
+            if lineWidth > width {
+                return RenderWidthViolation(
+                    lineIndex: index,
+                    visibleWidth: lineWidth,
+                    maximumWidth: width)
+            }
+        }
+        return nil
+    }
+
+    private func validateRenderedLines(_ lines: [String], width: Int, from start: Int = 0) {
+        guard let violation = Self.firstRenderWidthViolation(in: lines, width: width, from: start) else { return }
+        preconditionFailure(
+            "Rendered line \(violation.lineIndex) exceeds terminal width " +
+                "(\(violation.visibleWidth) > \(violation.maximumWidth))")
+    }
+
+    private nonisolated static func containsImage(_ line: String) -> Bool {
         line.contains("\u{001B}_G") || line.contains("\u{001B}]1337;File=")
     }
 

--- a/Tests/TauTUITests/TUITests.swift
+++ b/Tests/TauTUITests/TUITests.swift
@@ -87,6 +87,23 @@ struct TUIRenderingTests {
         #expect(last.contains("\u{001B}[?2026h"))
     }
 
+    @Test
+    func `full and partial render ranges report the same width violation`() {
+        let lines = ["fits", "\u{001B}[31m123456\u{001B}[0m"]
+        let expected = TUI.RenderWidthViolation(lineIndex: 1, visibleWidth: 6, maximumWidth: 5)
+
+        #expect(TUI.firstRenderWidthViolation(in: lines, width: 5) == expected)
+        #expect(TUI.firstRenderWidthViolation(in: lines, width: 5, from: 1) == expected)
+    }
+
+    @Test
+    func `render width validation exempts embedded image payloads`() {
+        let kitty = "prefix\u{001B}_Ga=t,f=100;AAAA\u{001B}\\suffix"
+        let iTerm = "prefix\u{001B}]1337;File=inline=1:AAAA\u{0007}suffix"
+
+        #expect(TUI.firstRenderWidthViolation(in: [kitty, iTerm], width: 1) == nil)
+    }
+
     @MainActor @Test
     func `partial diff clears extra old lines`() throws {
         let terminal = VirtualTerminal(columns: 20, rows: 5)

--- a/docs/pitui-sync.md
+++ b/docs/pitui-sync.md
@@ -12,6 +12,7 @@ Context: the current upstream checkout lives at `../../oss/pi-mono` (`/Users/ste
 - Open autocomplete results re-query after cursor movement and destructive edits so accepting a suggestion cannot apply a result for an old cursor position.
 - ProcessTerminal now treats descriptor input as a byte stream, retaining split UTF-8 scalars, CSI/Kitty sequences, and bracketed-paste delimiters between reads.
 - The main-screen renderer now redraws on height-only terminal resizes so its viewport model stays aligned.
+- Full and partial main-screen redraws now enforce the same visible-width invariant before writing component output.
 - Background styles now reapply only after internal resets and always terminate with their configured reset sequence.
 - ANSI-aware wrapping normalizes CRLF and CR line endings before layout.
 


### PR DESCRIPTION
## Summary

- centralize the main-screen visible-width invariant in one validator shared by full and partial redraws
- validate first renders, resizes, and viewport resets before terminal output instead of only checking differential updates
- pass the captured render width through dispatch so validation and layout use the same viewport snapshot
- preserve Kitty/iTerm image exemptions and keep partial validation limited to the changed tail

## Regression proof

Before the implementation, the focused regression failed because no shared full/partial validator existed and first/full redraws bypassed the partial writer's one-off precondition. The new tests cover ANSI-aware width measurement, equivalent full/partial range results, and both embedded image escape formats.

## Validation

- `swift test --parallel` (179 tests across both test targets)
- `swift build --configuration release`
- `swiftlint --config .swiftlint.yml`
- `swiftformat --lint . --config .swiftformat`
- `actionlint`
- Codex autoreview: clean, no accepted/actionable findings

## Follow-up boundary

The `Terminal.start` callback actor contract remains a separate API decision: `ProcessTerminal` currently dispatches callbacks on the main queue, while the protocol and `VirtualTerminal` do not encode a `MainActor` guarantee. This PR does not mix that conformer migration into the renderer fix.
